### PR TITLE
Converted Amount Type to Decimal

### DIFF
--- a/src/backend/prisma/migrations/20250919151919_expense_backend/migration.sql
+++ b/src/backend/prisma/migrations/20250919151919_expense_backend/migration.sql
@@ -1,7 +1,7 @@
 -- CreateTable
 CREATE TABLE `Expense` (
     `id` BIGINT NOT NULL AUTO_INCREMENT,
-    `amount` INTEGER NOT NULL,
+    `amount` DECIMAL(10, 2) NOT NULL,
     `date` DATETIME(3) NOT NULL,
     `category` ENUM('Food', 'Groceries', 'Mobile_Bill', 'Travel', 'Shopping', 'Games', 'Subscription', 'EMI') NOT NULL,
     `description` VARCHAR(191) NULL,

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -9,7 +9,7 @@ datasource db {
 
 model Expense{
   id          BigInt         @id         @default(autoincrement())
-  amount      Int            
+  amount      Decimal                    @db.Decimal(10, 2)    
   date        DateTime       
   category    Category       
   description String?


### PR DESCRIPTION
Converted the amount expense type from integer to decimal as expense amounts are not expected to be integers. Used decimal because it has high precision number and it is designed to prevent any floating point errors. 