### PR TITLE
TypeScript type mismatch

### DIFF
--- a/src/utils/useCrud.tsx
+++ b/src/utils/useCrud.tsx
@@ -1,4 +1,4 @@
-import type { Expense } from "../types";
+import type { Expense, newExpense } from "../types";
 import { useEffect, useState } from "react";
 // import useSaveExpense from "./useSaveExpense";
 
@@ -24,7 +24,7 @@ const useCrud = () => {
     };
     fetchExpenses();
   }, []);
-  const addExpense = async (expense: Expense) => {
+  const addExpense = async (expense: newExpense) => {
     try {
       const res = await fetch(API_URL, {
         method: "POST",


### PR DESCRIPTION
there was an issue with the onAddExpense prop in the ExpenseTracker component. The onAddExpense prop was defined as an Expense type which has an id. I had to go and change it to newExpense which doesn't have an id. That solved the issue.