### PR TITLE
Add receipt-parser and RAG assistant benchmark scripts

### DIFF
--- a/benchmarks/rag-assistant/results.json
+++ b/benchmarks/rag-assistant/results.json
@@ -1,0 +1,102 @@
+{
+  "generatedAt": "2026-07-07T22:07:27.680Z",
+  "accuracy": 100,
+  "passCount": 13,
+  "totalQuestions": 13,
+  "avgLatencyMs": 2076.498999999997,
+  "minLatencyMs": 414.62279999999737,
+  "maxLatencyMs": 9505.575599999996,
+  "results": [
+    {
+      "question": "What was my most recent expense?",
+      "answer": "Your most recent expense was $45 on Food on 2026-07-07, using a CREDIT_CARD at Sushi Palace.",
+      "pass": true,
+      "latencyMs": 893.929999999993,
+      "notes": "Recency lookup, expense side."
+    },
+    {
+      "question": "What was my most recent income?",
+      "answer": "Your most recent income was $4000 from Salary on 2026-07-07.",
+      "pass": true,
+      "latencyMs": 557.8606,
+      "notes": "Recency lookup, income side."
+    },
+    {
+      "question": "How much did I spend on my flight to Chicago?",
+      "answer": "You spent $250 on your flight to Chicago.",
+      "pass": true,
+      "latencyMs": 472.82829999999376,
+      "notes": "Specific-record recall via semantic search."
+    },
+    {
+      "question": "What did I spend on Netflix?",
+      "answer": "You spent $12.99 on Netflix on 2026-06-23.",
+      "pass": true,
+      "latencyMs": 414.62279999999737,
+      "notes": "Specific-record recall."
+    },
+    {
+      "question": "How much is my car loan EMI payment?",
+      "answer": "You spent $300 on car loan EMI payment on 2026-06-17.",
+      "pass": true,
+      "latencyMs": 453.99559999999474,
+      "notes": "Specific-record recall."
+    },
+    {
+      "question": "Did I receive any gift money recently?",
+      "answer": "Yes, you received a gift of $50 on 2026-06-29 from your parents.",
+      "pass": true,
+      "latencyMs": 558.9636000000028,
+      "notes": "Semantic category match."
+    },
+    {
+      "question": "What payment method did I use for my grocery shopping?",
+      "answer": "You used DEBIT_CARD for your grocery shopping.",
+      "pass": true,
+      "latencyMs": 502.33009999999194,
+      "notes": "Attribute recall, not just amount."
+    },
+    {
+      "question": "How much was my June salary?",
+      "answer": "To find your June salary, I'll look for the relevant records. \n\nOn 2026-06-04, I earned $3900 from Salary. Payment method: UPI. Description: June salary deposit.\n\nSo, your June salary was $3900.",
+      "pass": true,
+      "latencyMs": 510.94779999999446,
+      "notes": "Disambiguates from the more recent July salary via semantic search."
+    },
+    {
+      "question": "What did I buy running shoes for?",
+      "answer": "You bought running shoes for $89.99 on 2026-06-30. The description of the transaction is \"New running shoes.\"",
+      "pass": true,
+      "latencyMs": 512.9793999999965,
+      "notes": "Specific-record recall."
+    },
+    {
+      "question": "Is my phone bill a recurring expense?",
+      "answer": "Based on the provided context, your phone bill is $60 on 2026-07-05 and another $60 on 2026-07-05. This suggests that your phone bill is a recurring expense, as it appears to be paid on the same date.",
+      "pass": true,
+      "latencyMs": 512.0577000000048,
+      "notes": "Yes/no fact recall."
+    },
+    {
+      "question": "How much cashback reward did I get?",
+      "answer": "You earned $100 from a cashback reward on 2026-05-28.",
+      "pass": true,
+      "latencyMs": 6449.066200000001,
+      "notes": "Specific-record recall."
+    },
+    {
+      "question": "What did I spend money on for entertainment or games?",
+      "answer": "Based on the provided context, you spent money on the following entertainment or games:\n\n- On 2026-06-27, you spent $15 on Games. Payment method: CREDIT_CARD. Description: Steam game purchase.\n- On 2026-06-23, you spent $12.99 on Subscription. Payment method: CREDIT_CARD. Description: Netflix subscription.\n- On 2026-07-07, you spent $45 on Food. Payment method: CREDIT_CARD. Description: Dinner at Sushi Palace. (Note: While this is not strictly entertainment or games, it could be considered as dining out for entertainment purposes.)",
+      "pass": true,
+      "latencyMs": 9505.575599999996,
+      "notes": "Semantic category match, ambiguous phrasing."
+    },
+    {
+      "question": "How much did I spend on rent last year?",
+      "answer": "I don't know.",
+      "pass": true,
+      "latencyMs": 5649.329299999998,
+      "notes": "Out-of-context question — the assistant must decline rather than hallucinate a rent expense that was never recorded."
+    }
+  ]
+}

--- a/benchmarks/rag-assistant/results.md
+++ b/benchmarks/rag-assistant/results.md
@@ -1,0 +1,26 @@
+# RAG Financial Assistant Benchmark Results
+
+Generated: 2026-07-07T22:07:27.643Z
+
+**Overall accuracy: 100.0% (13/13 questions)**
+**Latency — avg: 2076ms, min: 415ms, max: 9506ms**
+
+Seed data: 10 expenses + 6 incomes, deterministic amounts/categories/dates, indexed via the same `RagService.indexExpense/indexIncome` path used in production.
+
+## Question-by-question results
+
+| # | Question | Pass | Latency (ms) | Answer |
+|---|---|---|---|---|
+| 1 | What was my most recent expense? | PASS | 894 | Your most recent expense was $45 on Food on 2026-07-07, using a CREDIT_CARD at Sushi Palace. |
+| 2 | What was my most recent income? | PASS | 558 | Your most recent income was $4000 from Salary on 2026-07-07. |
+| 3 | How much did I spend on my flight to Chicago? | PASS | 473 | You spent $250 on your flight to Chicago. |
+| 4 | What did I spend on Netflix? | PASS | 415 | You spent $12.99 on Netflix on 2026-06-23. |
+| 5 | How much is my car loan EMI payment? | PASS | 454 | You spent $300 on car loan EMI payment on 2026-06-17. |
+| 6 | Did I receive any gift money recently? | PASS | 559 | Yes, you received a gift of $50 on 2026-06-29 from your parents. |
+| 7 | What payment method did I use for my grocery shopping? | PASS | 502 | You used DEBIT_CARD for your grocery shopping. |
+| 8 | How much was my June salary? | PASS | 511 | To find your June salary, I'll look for the relevant records.   On 2026-06-04, I earned $3900 from Salary. Payment method: UPI. Description: June salary deposit |
+| 9 | What did I buy running shoes for? | PASS | 513 | You bought running shoes for $89.99 on 2026-06-30. The description of the transaction is "New running shoes." |
+| 10 | Is my phone bill a recurring expense? | PASS | 512 | Based on the provided context, your phone bill is $60 on 2026-07-05 and another $60 on 2026-07-05. This suggests that your phone bill is a recurring expense, as |
+| 11 | How much cashback reward did I get? | PASS | 6449 | You earned $100 from a cashback reward on 2026-05-28. |
+| 12 | What did I spend money on for entertainment or games? | PASS | 9506 | Based on the provided context, you spent money on the following entertainment or games:  - On 2026-06-27, you spent $15 on Games. Payment method: CREDIT_CARD. D |
+| 13 | How much did I spend on rent last year? | PASS | 5649 | I don't know. |

--- a/benchmarks/receipt-parser/results.json
+++ b/benchmarks/receipt-parser/results.json
@@ -1,0 +1,352 @@
+{
+  "generatedAt": "2026-07-07T21:34:36.991Z",
+  "accuracy": 93.54838709677419,
+  "passCount": 29,
+  "totalCases": 31,
+  "byTag": {
+    "standard": {
+      "pass": 13,
+      "total": 13
+    },
+    "real-world-merchant": {
+      "pass": 10,
+      "total": 10
+    },
+    "international": {
+      "pass": 3,
+      "total": 3
+    },
+    "fallback": {
+      "pass": 3,
+      "total": 3
+    },
+    "discount": {
+      "pass": 1,
+      "total": 1
+    },
+    "tax-handling": {
+      "pass": 3,
+      "total": 3
+    },
+    "subtotal-handling": {
+      "pass": 3,
+      "total": 3
+    },
+    "ocr-noise": {
+      "pass": 3,
+      "total": 4
+    },
+    "known-limitation": {
+      "pass": 2,
+      "total": 4
+    },
+    "distractor": {
+      "pass": 2,
+      "total": 2
+    },
+    "currency-format": {
+      "pass": 4,
+      "total": 4
+    }
+  },
+  "results": [
+    {
+      "label": "Starbucks - simple total",
+      "tags": [
+        "standard",
+        "real-world-merchant"
+      ],
+      "expectedTotal": 8.2,
+      "actual": 8.2,
+      "pass": true
+    },
+    {
+      "label": "Walmart grocery - tabbed items",
+      "tags": [
+        "standard",
+        "real-world-merchant"
+      ],
+      "expectedTotal": 12.79,
+      "actual": 12.79,
+      "pass": true
+    },
+    {
+      "label": "Uber ride receipt",
+      "tags": [
+        "standard",
+        "real-world-merchant"
+      ],
+      "expectedTotal": 23.45,
+      "actual": 23.45,
+      "pass": true
+    },
+    {
+      "label": "Shell gas station",
+      "tags": [
+        "standard",
+        "real-world-merchant"
+      ],
+      "expectedTotal": 42.1,
+      "actual": 42.1,
+      "pass": true
+    },
+    {
+      "label": "CVS pharmacy co-pay",
+      "tags": [
+        "standard",
+        "real-world-merchant"
+      ],
+      "expectedTotal": 8.99,
+      "actual": 8.99,
+      "pass": true
+    },
+    {
+      "label": "Restaurant with tip added",
+      "tags": [
+        "standard",
+        "real-world-merchant"
+      ],
+      "expectedTotal": 26.89,
+      "actual": 26.89,
+      "pass": true
+    },
+    {
+      "label": "Hotel folio",
+      "tags": [
+        "standard",
+        "real-world-merchant"
+      ],
+      "expectedTotal": 322.28,
+      "actual": 322.28,
+      "pass": true
+    },
+    {
+      "label": "E-commerce order confirmation",
+      "tags": [
+        "standard",
+        "real-world-merchant"
+      ],
+      "expectedTotal": 32.09,
+      "actual": 32.09,
+      "pass": true
+    },
+    {
+      "label": "REWE German supermarket (Summe, no English keyword)",
+      "tags": [
+        "international",
+        "fallback"
+      ],
+      "expectedTotal": 4.28,
+      "actual": 4.28,
+      "pass": true
+    },
+    {
+      "label": "Airport parking - Amount Due keyword",
+      "tags": [
+        "standard"
+      ],
+      "expectedTotal": 19.5,
+      "actual": 19.5,
+      "pass": true
+    },
+    {
+      "label": "Coffee shop with coupon discount",
+      "tags": [
+        "discount",
+        "real-world-merchant"
+      ],
+      "expectedTotal": 3.5,
+      "actual": 3.5,
+      "pass": true
+    },
+    {
+      "label": "Electronics store - multiple tax lines",
+      "tags": [
+        "standard",
+        "tax-handling"
+      ],
+      "expectedTotal": 14.16,
+      "actual": 14.16,
+      "pass": true
+    },
+    {
+      "label": "Grocery store - Balance keyword",
+      "tags": [
+        "standard"
+      ],
+      "expectedTotal": 9.48,
+      "actual": 9.48,
+      "pass": true
+    },
+    {
+      "label": "Receipt with only a Subtotal line, no Total at all",
+      "tags": [
+        "fallback",
+        "subtotal-handling"
+      ],
+      "expectedTotal": 4,
+      "actual": 4,
+      "pass": true
+    },
+    {
+      "label": "OCR noise: currency glued to keyword, no space",
+      "tags": [
+        "ocr-noise",
+        "real-world-merchant"
+      ],
+      "expectedTotal": 45,
+      "actual": 45,
+      "pass": true
+    },
+    {
+      "label": "OCR noise: 'Total' keyword broken by stray spaces",
+      "tags": [
+        "ocr-noise",
+        "known-limitation"
+      ],
+      "expectedTotal": 3.25,
+      "actual": 3.25,
+      "pass": true
+    },
+    {
+      "label": "Whole-dollar total with no cents printed",
+      "tags": [
+        "ocr-noise",
+        "known-limitation"
+      ],
+      "expectedTotal": 45,
+      "actual": null,
+      "pass": false
+    },
+    {
+      "label": "Three-decimal currency (Kuwaiti Dinar style)",
+      "tags": [
+        "international",
+        "known-limitation"
+      ],
+      "expectedTotal": 8,
+      "actual": 8,
+      "pass": true
+    },
+    {
+      "label": "All-caps TOTAL with OCR garbage characters",
+      "tags": [
+        "ocr-noise"
+      ],
+      "expectedTotal": 1.5,
+      "actual": 1.5,
+      "pass": true
+    },
+    {
+      "label": "'Total Items' count line before the real total",
+      "tags": [
+        "standard",
+        "distractor"
+      ],
+      "expectedTotal": 7,
+      "actual": 7,
+      "pass": true
+    },
+    {
+      "label": "Refund receipt with negative total",
+      "tags": [
+        "known-limitation"
+      ],
+      "expectedTotal": -15,
+      "actual": 15,
+      "pass": false
+    },
+    {
+      "label": "Minimal receipt - bare number only",
+      "tags": [
+        "fallback"
+      ],
+      "expectedTotal": 12.99,
+      "actual": 12.99,
+      "pass": true
+    },
+    {
+      "label": "Euro symbol receipt",
+      "tags": [
+        "currency-format"
+      ],
+      "expectedTotal": 4.3,
+      "actual": 4.3,
+      "pass": true
+    },
+    {
+      "label": "Pound sterling receipt",
+      "tags": [
+        "currency-format"
+      ],
+      "expectedTotal": 4.7,
+      "actual": 4.7,
+      "pass": true
+    },
+    {
+      "label": "Large US total with thousands separator",
+      "tags": [
+        "currency-format"
+      ],
+      "expectedTotal": 2137.9,
+      "actual": 2137.9,
+      "pass": true
+    },
+    {
+      "label": "Large European total with thousands separator",
+      "tags": [
+        "currency-format",
+        "international"
+      ],
+      "expectedTotal": 2033.9,
+      "actual": 2033.9,
+      "pass": true
+    },
+    {
+      "label": "Grand Total overrides earlier partial total",
+      "tags": [
+        "standard",
+        "subtotal-handling"
+      ],
+      "expectedTotal": 15.2,
+      "actual": 15.2,
+      "pass": true
+    },
+    {
+      "label": "'Sub Total' spaced variant correctly skipped",
+      "tags": [
+        "subtotal-handling"
+      ],
+      "expectedTotal": 4.35,
+      "actual": 4.35,
+      "pass": true
+    },
+    {
+      "label": "'Total (incl. tax)' single line",
+      "tags": [
+        "tax-handling"
+      ],
+      "expectedTotal": 8.5,
+      "actual": 8.5,
+      "pass": true
+    },
+    {
+      "label": "Date and phone number distractors",
+      "tags": [
+        "distractor"
+      ],
+      "expectedTotal": 45,
+      "actual": 45,
+      "pass": true
+    },
+    {
+      "label": "Receipt with VAT-only line correctly skipped",
+      "tags": [
+        "tax-handling"
+      ],
+      "expectedTotal": 3.2,
+      "actual": 3.2,
+      "pass": true
+    }
+  ]
+}

--- a/benchmarks/receipt-parser/results.md
+++ b/benchmarks/receipt-parser/results.md
@@ -1,0 +1,62 @@
+# Receipt Parser Benchmark Results
+
+Generated: 2026-07-07T21:34:36.985Z
+
+**Overall accuracy: 93.5% (29/31 cases)**
+
+## Accuracy by category
+
+| Category | Pass | Total | Accuracy |
+|---|---|---|---|
+| currency-format | 4 | 4 | 100% |
+| discount | 1 | 1 | 100% |
+| distractor | 2 | 2 | 100% |
+| fallback | 3 | 3 | 100% |
+| international | 3 | 3 | 100% |
+| known-limitation | 2 | 4 | 50% |
+| ocr-noise | 3 | 4 | 75% |
+| real-world-merchant | 10 | 10 | 100% |
+| standard | 13 | 13 | 100% |
+| subtotal-handling | 3 | 3 | 100% |
+| tax-handling | 3 | 3 | 100% |
+
+## Case-by-case results
+
+| # | Label | Expected | Actual | Pass |
+|---|---|---|---|---|
+| 1 | Starbucks - simple total | 8.2 | 8.2 | PASS |
+| 2 | Walmart grocery - tabbed items | 12.79 | 12.79 | PASS |
+| 3 | Uber ride receipt | 23.45 | 23.45 | PASS |
+| 4 | Shell gas station | 42.1 | 42.1 | PASS |
+| 5 | CVS pharmacy co-pay | 8.99 | 8.99 | PASS |
+| 6 | Restaurant with tip added | 26.89 | 26.89 | PASS |
+| 7 | Hotel folio | 322.28 | 322.28 | PASS |
+| 8 | E-commerce order confirmation | 32.09 | 32.09 | PASS |
+| 9 | REWE German supermarket (Summe, no English keyword) | 4.28 | 4.28 | PASS |
+| 10 | Airport parking - Amount Due keyword | 19.5 | 19.5 | PASS |
+| 11 | Coffee shop with coupon discount | 3.5 | 3.5 | PASS |
+| 12 | Electronics store - multiple tax lines | 14.16 | 14.16 | PASS |
+| 13 | Grocery store - Balance keyword | 9.48 | 9.48 | PASS |
+| 14 | Receipt with only a Subtotal line, no Total at all | 4 | 4 | PASS |
+| 15 | OCR noise: currency glued to keyword, no space | 45 | 45 | PASS |
+| 16 | OCR noise: 'Total' keyword broken by stray spaces | 3.25 | 3.25 | PASS |
+| 17 | Whole-dollar total with no cents printed | 45 | null | FAIL |
+| 18 | Three-decimal currency (Kuwaiti Dinar style) | 8 | 8 | PASS |
+| 19 | All-caps TOTAL with OCR garbage characters | 1.5 | 1.5 | PASS |
+| 20 | 'Total Items' count line before the real total | 7 | 7 | PASS |
+| 21 | Refund receipt with negative total | -15 | 15 | FAIL |
+| 22 | Minimal receipt - bare number only | 12.99 | 12.99 | PASS |
+| 23 | Euro symbol receipt | 4.3 | 4.3 | PASS |
+| 24 | Pound sterling receipt | 4.7 | 4.7 | PASS |
+| 25 | Large US total with thousands separator | 2137.9 | 2137.9 | PASS |
+| 26 | Large European total with thousands separator | 2033.9 | 2033.9 | PASS |
+| 27 | Grand Total overrides earlier partial total | 15.2 | 15.2 | PASS |
+| 28 | 'Sub Total' spaced variant correctly skipped | 4.35 | 4.35 | PASS |
+| 29 | 'Total (incl. tax)' single line | 8.5 | 8.5 | PASS |
+| 30 | Date and phone number distractors | 45 | 45 | PASS |
+| 31 | Receipt with VAT-only line correctly skipped | 3.2 | 3.2 | PASS |
+
+## Failures / known limitations
+
+- **Whole-dollar total with no cents printed** — expected 45, got null. Regex requires exactly 2 decimal digits, so a receipt where amounts are printed without cents cannot be matched at all.
+- **Refund receipt with negative total** — expected -15, got 15. Parser has no minus-sign handling, so refunds are expected to come back as a positive number instead of negative — a known limitation worth flagging.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "npm run docker:up && npx wait-on tcp:3306 -t 30000 && npm run dev:full",
     "build": "tsc -b && vite build",
     "test": "vitest --environment jsdom --globals",
+    "bench:receipts": "vitest run src/utils/receiptParser.bench.test.ts",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -25,6 +25,7 @@
         "chromadb": "^3.3.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "dotenv-expand": "^13.0.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "langchain": "^1.2.25",
@@ -2462,6 +2463,33 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-13.0.0.tgz",
+      "integrity": "sha512-aBfBS8eYIeXmpHI9ThIlA7/WLq+SLt18iXUZhb52rW89QLKQFoIpPG1bPeewoPZsTyjSSO3T7234FBVUM1V2rA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^17.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "nodemon --exec tsx ./src/index.ts",
     "build": "tsc && tsc-alias",
-    "start": "node ./dist/index.js"
+    "start": "node ./dist/index.js",
+    "bench:rag": "tsx ./src/rag-benchmark.ts"
   },
   "keywords": [],
   "author": "",
@@ -29,6 +30,7 @@
     "chromadb": "^3.3.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
+    "dotenv-expand": "^13.0.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "langchain": "^1.2.25",

--- a/src/backend/src/rag-benchmark.ts
+++ b/src/backend/src/rag-benchmark.ts
@@ -1,0 +1,273 @@
+import dotenv from "dotenv";
+import dotenvExpand from "dotenv-expand";
+import path from "path";
+import fs from "node:fs";
+import { fileURLToPath } from "url";
+import bcrypt from "bcrypt";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenvExpand.expand(dotenv.config({ path: path.resolve(__dirname, "../../../.env") }));
+
+import { prisma } from "./db.js";
+import RagService from "./services/rag.service.js";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Gemini's free tier rate-limits embedding calls; seed-vectors.ts uses the
+// same 4.5s spacing. Override with RAG_BENCH_DELAY_MS if you're on a paid tier.
+const INDEX_DELAY_MS = Number(process.env.RAG_BENCH_DELAY_MS ?? 4500);
+const KEEP_DATA = process.argv.includes("--keep-data");
+
+const BENCH_USER = {
+  username: "rag_benchmark_user",
+  email: "rag-benchmark@test.local",
+};
+
+function daysAgo(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  d.setHours(12, 0, 0, 0);
+  return d;
+}
+
+const EXPENSE_SEED = [
+  { amount: 45.0, category: "Food", daysAgo: 0, description: "Dinner at Sushi Palace", paymentMethod: "CREDIT_CARD", isRecurring: false },
+  { amount: 120.5, category: "Groceries", daysAgo: 1, description: "Weekly grocery shopping at Walmart", paymentMethod: "DEBIT_CARD", isRecurring: false },
+  { amount: 60.0, category: "Mobile_Bill", daysAgo: 2, description: "Monthly phone bill", paymentMethod: "UPI", isRecurring: true },
+  { amount: 250.0, category: "Travel", daysAgo: 5, description: "Flight ticket to Chicago", paymentMethod: "CREDIT_CARD", isRecurring: false },
+  { amount: 89.99, category: "Shopping", daysAgo: 7, description: "New running shoes", paymentMethod: "DEBIT_CARD", isRecurring: false },
+  { amount: 15.0, category: "Games", daysAgo: 10, description: "Steam game purchase", paymentMethod: "CREDIT_CARD", isRecurring: false },
+  { amount: 12.99, category: "Subscription", daysAgo: 14, description: "Netflix subscription", paymentMethod: "CREDIT_CARD", isRecurring: true },
+  { amount: 300.0, category: "EMI", daysAgo: 20, description: "Car loan EMI payment", paymentMethod: "UPI", isRecurring: true },
+  { amount: 35.0, category: "Food", daysAgo: 25, description: "Lunch with coworkers", paymentMethod: "CASH", isRecurring: false },
+  { amount: 500.0, category: "Travel", daysAgo: 30, description: "Hotel booking for vacation", paymentMethod: "CREDIT_CARD", isRecurring: false },
+] as const;
+
+const INCOME_SEED = [
+  { amount: 4000.0, category: "Salary", daysAgo: 0, description: "July salary deposit", paymentMethod: "UPI" },
+  { amount: 600.0, category: "Freelance", daysAgo: 3, description: "Freelance web design project payment", paymentMethod: "UPI" },
+  { amount: 50.0, category: "Gift", daysAgo: 8, description: "Birthday gift from parents", paymentMethod: "CASH" },
+  { amount: 200.0, category: "Investment", daysAgo: 15, description: "Dividend payout from stocks", paymentMethod: "DEBIT_CARD" },
+  { amount: 3900.0, category: "Salary", daysAgo: 33, description: "June salary deposit", paymentMethod: "UPI" },
+  { amount: 100.0, category: "Other", daysAgo: 40, description: "Cashback reward", paymentMethod: "CREDIT_CARD" },
+] as const;
+
+type Check = string[]; // OR-matched synonyms; a question passes a check if ANY synonym is found
+
+type BenchQuestion = {
+  question: string;
+  checks: Check[]; // ALL checks must match (AND of groups, OR within group)
+  notes: string;
+};
+
+const QUESTIONS: BenchQuestion[] = [
+  { question: "What was my most recent expense?", checks: [["45", "45.00"], ["sushi", "food", "dinner"]], notes: "Recency lookup, expense side." },
+  { question: "What was my most recent income?", checks: [["4000", "4,000"], ["salary", "july"]], notes: "Recency lookup, income side." },
+  { question: "How much did I spend on my flight to Chicago?", checks: [["250"]], notes: "Specific-record recall via semantic search." },
+  { question: "What did I spend on Netflix?", checks: [["12.99", "12.9"], ["netflix"]], notes: "Specific-record recall." },
+  { question: "How much is my car loan EMI payment?", checks: [["300"]], notes: "Specific-record recall." },
+  { question: "Did I receive any gift money recently?", checks: [["50"], ["gift", "birthday"]], notes: "Semantic category match." },
+  { question: "What payment method did I use for my grocery shopping?", checks: [["debit"]], notes: "Attribute recall, not just amount." },
+  { question: "How much was my June salary?", checks: [["3900", "3,900"]], notes: "Disambiguates from the more recent July salary via semantic search." },
+  { question: "What did I buy running shoes for?", checks: [["89.99", "89.9"]], notes: "Specific-record recall." },
+  { question: "Is my phone bill a recurring expense?", checks: [["yes", "recurring"]], notes: "Yes/no fact recall." },
+  { question: "How much cashback reward did I get?", checks: [["100"]], notes: "Specific-record recall." },
+  { question: "What did I spend money on for entertainment or games?", checks: [["steam", "game", "15"]], notes: "Semantic category match, ambiguous phrasing." },
+  {
+    question: "How much did I spend on rent last year?",
+    checks: [["don't know", "do not know", "couldn't find", "could not find", "no information", "not available", "no relevant"]],
+    notes: "Out-of-context question — the assistant must decline rather than hallucinate a rent expense that was never recorded.",
+  },
+];
+
+function containsAny(haystack: string, needles: string[]): boolean {
+  const lower = haystack.toLowerCase();
+  return needles.some((n) => lower.includes(n.toLowerCase()));
+}
+
+async function main() {
+  console.log("=== RAG Financial Assistant Benchmark ===\n");
+
+  // 1. Clean slate: remove any leftover benchmark user + their data from a prior run.
+  const existing = await prisma.user.findUnique({ where: { email: BENCH_USER.email } });
+  if (existing) {
+    console.log("Found leftover benchmark user from a previous run — cleaning up first...");
+    const oldExpenses = await prisma.expense.findMany({ where: { userId: existing.id } });
+    const oldIncomes = await prisma.income.findMany({ where: { userId: existing.id } });
+    for (const e of oldExpenses) {
+      try {
+        await RagService.deleteIndexedExpense(e.id);
+      } catch (err) {
+        console.warn(`  (non-fatal) failed to delete old vector for expense ${e.id}:`, (err as Error).message);
+      }
+    }
+    for (const i of oldIncomes) {
+      try {
+        await RagService.deleteIndexedIncome(i.id);
+      } catch (err) {
+        console.warn(`  (non-fatal) failed to delete old vector for income ${i.id}:`, (err as Error).message);
+      }
+    }
+    await prisma.user.delete({ where: { id: existing.id } }); // cascades to expenses/incomes
+  }
+
+  // 2. Create a fresh dedicated benchmark user.
+  const passwordHash = await bcrypt.hash("Benchmark-Only-1!", 10);
+  const user = await prisma.user.create({
+    data: { username: BENCH_USER.username, email: BENCH_USER.email, password: passwordHash },
+  });
+  console.log(`Created benchmark user id=${user.id}\n`);
+
+  // 3. Seed deterministic expenses/incomes and index each into Pinecone.
+  console.log(`Seeding ${EXPENSE_SEED.length} expenses + ${INCOME_SEED.length} incomes (indexing with ${INDEX_DELAY_MS}ms spacing to respect embedding rate limits)...`);
+
+  let indexed = 0;
+  const totalToIndex = EXPENSE_SEED.length + INCOME_SEED.length;
+
+  for (const e of EXPENSE_SEED) {
+    const expense = await prisma.expense.create({
+      data: {
+        amount: e.amount,
+        category: e.category as never,
+        date: daysAgo(e.daysAgo),
+        description: e.description,
+        userId: user.id,
+        paymentMethod: e.paymentMethod as never,
+        isRecurring: e.isRecurring,
+      },
+    });
+    await RagService.indexExpense(expense);
+    indexed++;
+    process.stdout.write(`\r  Indexed ${indexed}/${totalToIndex}`);
+    await delay(INDEX_DELAY_MS);
+  }
+
+  for (const i of INCOME_SEED) {
+    const income = await prisma.income.create({
+      data: {
+        amount: i.amount,
+        category: i.category as never,
+        date: daysAgo(i.daysAgo),
+        description: i.description,
+        userId: user.id,
+        paymentMethod: i.paymentMethod as never,
+      },
+    });
+    await RagService.indexIncome(income as never);
+    indexed++;
+    process.stdout.write(`\r  Indexed ${indexed}/${totalToIndex}`);
+    await delay(INDEX_DELAY_MS);
+  }
+  console.log("\nIndexing complete. Waiting 5s for Pinecone consistency...\n");
+  await delay(5000);
+
+  // 4. Ask each benchmark question and grade the answer.
+  console.log(`Running ${QUESTIONS.length} benchmark questions...\n`);
+  const results: Array<{
+    question: string;
+    answer: string;
+    pass: boolean;
+    latencyMs: number;
+    notes: string;
+    error: string | undefined;
+  }> = [];
+
+  for (const q of QUESTIONS) {
+    const start = performance.now();
+    let answer = "";
+    let error: string | undefined;
+    try {
+      answer = await RagService.askFinancialAssistant(user.id, q.question);
+    } catch (err) {
+      error = (err as Error).message;
+    }
+    const latencyMs = performance.now() - start;
+    const pass = !error && q.checks.every((group) => containsAny(answer, group));
+    results.push({ question: q.question, answer, pass, latencyMs, notes: q.notes, error });
+    console.log(`  [${pass ? "PASS" : "FAIL"}] (${latencyMs.toFixed(0)}ms) ${q.question}`);
+  }
+
+  // 5. Compute metrics + write report.
+  const passCount = results.filter((r) => r.pass).length;
+  const accuracy = (passCount / results.length) * 100;
+  const latencies = results.map((r) => r.latencyMs);
+  const avgLatency = latencies.reduce((a, b) => a + b, 0) / latencies.length;
+  const maxLatency = Math.max(...latencies);
+  const minLatency = Math.min(...latencies);
+
+  const lines: string[] = [];
+  lines.push("# RAG Financial Assistant Benchmark Results");
+  lines.push("");
+  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push("");
+  lines.push(`**Overall accuracy: ${accuracy.toFixed(1)}% (${passCount}/${results.length} questions)**`);
+  lines.push(`**Latency — avg: ${avgLatency.toFixed(0)}ms, min: ${minLatency.toFixed(0)}ms, max: ${maxLatency.toFixed(0)}ms**`);
+  lines.push("");
+  lines.push("Seed data: 10 expenses + 6 incomes, deterministic amounts/categories/dates, indexed via the same `RagService.indexExpense/indexIncome` path used in production.");
+  lines.push("");
+  lines.push("## Question-by-question results");
+  lines.push("");
+  lines.push("| # | Question | Pass | Latency (ms) | Answer |");
+  lines.push("|---|---|---|---|---|");
+  results.forEach((r, i) => {
+    const shortAnswer = (r.error ? `ERROR: ${r.error}` : r.answer).replace(/\n/g, " ").slice(0, 160);
+    lines.push(`| ${i + 1} | ${r.question} | ${r.pass ? "PASS" : "FAIL"} | ${r.latencyMs.toFixed(0)} | ${shortAnswer} |`);
+  });
+
+  const failures = results.filter((r) => !r.pass);
+  if (failures.length > 0) {
+    lines.push("");
+    lines.push("## Failures");
+    lines.push("");
+    for (const f of failures) {
+      lines.push(`- **${f.question}** — ${f.notes}`);
+      lines.push(`  - Answer: ${f.error ? `ERROR: ${f.error}` : f.answer}`);
+    }
+  }
+
+  const report = lines.join("\n");
+  const outDir = path.resolve(__dirname, "../../../benchmarks/rag-assistant");
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, "results.md"), report);
+  fs.writeFileSync(
+    path.join(outDir, "results.json"),
+    JSON.stringify({ generatedAt: new Date().toISOString(), accuracy, passCount, totalQuestions: results.length, avgLatencyMs: avgLatency, minLatencyMs: minLatency, maxLatencyMs: maxLatency, results }, null, 2),
+  );
+
+  console.log("\n" + report + "\n");
+  console.log(`Report written to ${outDir}`);
+
+  // 6. Cleanup (unless --keep-data was passed).
+  if (!KEEP_DATA) {
+    console.log("\nCleaning up benchmark data...");
+    const expenses = await prisma.expense.findMany({ where: { userId: user.id } });
+    const incomes = await prisma.income.findMany({ where: { userId: user.id } });
+    for (const e of expenses) {
+      try {
+        await RagService.deleteIndexedExpense(e.id);
+      } catch {
+        // non-fatal
+      }
+    }
+    for (const i of incomes) {
+      try {
+        await RagService.deleteIndexedIncome(i.id);
+      } catch {
+        // non-fatal
+      }
+    }
+    await prisma.user.delete({ where: { id: user.id } }); // cascades to expenses/incomes
+    console.log("Done — benchmark user, expenses, incomes, and vectors removed.");
+  } else {
+    console.log(`\n--keep-data passed: leaving benchmark user id=${user.id} and its data in place.`);
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("Fatal error running RAG benchmark:", err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/utils/receiptParser.bench.dataset.ts
+++ b/src/utils/receiptParser.bench.dataset.ts
@@ -1,0 +1,395 @@
+export type BenchmarkCase = {
+  label: string;
+  tags: string[];
+  rawText: string;
+  // Ground truth: what a human reading the receipt would consider correct.
+  // null means "no total is recoverable from this text at all".
+  expectedTotal: number | null;
+  notes: string;
+};
+
+export const benchmarkCases: BenchmarkCase[] = [
+  {
+    label: "Starbucks - simple total",
+    tags: ["standard", "real-world-merchant"],
+    rawText: `
+      Starbucks Store #4521
+      Grande Latte        4.95
+      Blueberry Muffin     3.25
+      Total               8.20
+      Thank you, come again!
+    `,
+    expectedTotal: 8.2,
+    notes: "Baseline case, clear Total keyword.",
+  },
+  {
+    label: "Walmart grocery - tabbed items",
+    tags: ["standard", "real-world-merchant"],
+    rawText: `
+      WALMART
+      Bananas          1.48
+      Milk 2%          3.29
+      Bread            2.99
+      Eggs             4.19
+      SUBTOTAL        11.95
+      TAX              0.84
+      TOTAL           12.79
+    `,
+    expectedTotal: 12.79,
+    notes: "Standard subtotal/tax/total pattern, all-caps keywords.",
+  },
+  {
+    label: "Uber ride receipt",
+    tags: ["standard", "real-world-merchant"],
+    rawText: `
+      Uber Trip Receipt
+      Fare                18.50
+      Booking Fee          2.25
+      Promotion           -2.70
+      Total charged      $23.45
+    `,
+    expectedTotal: 23.45,
+    notes: "Currency symbol glued directly to number with 'charged' after Total.",
+  },
+  {
+    label: "Shell gas station",
+    tags: ["standard", "real-world-merchant"],
+    rawText: `
+      SHELL #08841
+      Pump 03
+      Unleaded  10.523 gal
+      Price/Gal   4.00
+      Total Sale       $42.10
+    `,
+    expectedTotal: 42.1,
+    notes: "Contains a 3-decimal quantity (10.523) that must not be picked as the total.",
+  },
+  {
+    label: "CVS pharmacy co-pay",
+    tags: ["standard", "real-world-merchant"],
+    rawText: `
+      CVS PHARMACY
+      Rx#0294831
+      Amoxicillin 500mg
+      Insurance Covered   42.00
+      Total Due:           8.99
+    `,
+    expectedTotal: 8.99,
+    notes: "Larger insurance-covered amount appears before the real total.",
+  },
+  {
+    label: "Restaurant with tip added",
+    tags: ["standard", "real-world-merchant"],
+    rawText: `
+      Olive Garden
+      Chicken Parm       18.00
+      Iced Tea            3.00
+      Subtotal           21.00
+      Tax                 1.89
+      Tip                 4.00
+      Total              26.89
+    `,
+    expectedTotal: 26.89,
+    notes: "Tip line sits between subtotal/tax and the final total.",
+  },
+  {
+    label: "Hotel folio",
+    tags: ["standard", "real-world-merchant"],
+    rawText: `
+      Grand Plaza Hotel - Folio
+      Room Charge (2 nights)   258.00
+      Resort Fee                29.00
+      Occupancy Tax             35.28
+      Total Due Upon Checkout  322.28
+    `,
+    expectedTotal: 322.28,
+    notes: "Multi-word keyword phrase around 'Total Due'.",
+  },
+  {
+    label: "E-commerce order confirmation",
+    tags: ["standard", "real-world-merchant"],
+    rawText: `
+      Order Confirmation #55291
+      Wireless Mouse        24.99
+      Shipping               5.00
+      Estimated Tax          2.10
+      Order Total:          32.09
+    `,
+    expectedTotal: 32.09,
+    notes: "Not a printed receipt at all, but plain confirmation-email text.",
+  },
+  {
+    label: "REWE German supermarket (Summe, no English keyword)",
+    tags: ["international", "fallback"],
+    rawText: `
+      REWE Markt GmbH
+      Apfel             1,49
+      Brot              2,79
+      Summe            4,28
+    `,
+    expectedTotal: 4.28,
+    notes: "No English total keyword present at all; parser must fall back to largest number.",
+  },
+  {
+    label: "Airport parking - Amount Due keyword",
+    tags: ["standard"],
+    rawText: `
+      Airport Parking Garage
+      Duration: 3h 15m
+      Rate: $6.00/hr
+      Amount Due:   19.50
+    `,
+    expectedTotal: 19.5,
+    notes: "Uses 'Amount Due' rather than 'Total'.",
+  },
+  {
+    label: "Coffee shop with coupon discount",
+    tags: ["discount", "real-world-merchant"],
+    rawText: `
+      Corner Cafe
+      Cappuccino          4.50
+      Coupon Discount    -1.00
+      Total               3.50
+    `,
+    expectedTotal: 3.5,
+    notes: "Negative discount line precedes the real total.",
+  },
+  {
+    label: "Electronics store - multiple tax lines",
+    tags: ["standard", "tax-handling"],
+    rawText: `
+      Best Buy
+      USB-C Cable          12.99
+      State Tax             0.91
+      City Tax              0.26
+      Total                14.16
+    `,
+    expectedTotal: 14.16,
+    notes: "Two separate tax lines above the total; both must be skipped for the total line itself.",
+  },
+  {
+    label: "Grocery store - Balance keyword",
+    tags: ["standard"],
+    rawText: `
+      Trader Joe's
+      Trail Mix            5.99
+      Sparkling Water      3.49
+      Balance:             9.48
+    `,
+    expectedTotal: 9.48,
+    notes: "Uses 'Balance' instead of 'Total'.",
+  },
+  {
+    label: "Receipt with only a Subtotal line, no Total at all",
+    tags: ["fallback", "subtotal-handling"],
+    rawText: `
+      Corner Store
+      Chips        2.50
+      Soda         1.50
+      Subtotal     4.00
+    `,
+    expectedTotal: 4.0,
+    notes: "No real Total line exists; Subtotal is explicitly skipped by keyword match, so the parser must recover the value via the largest-number fallback.",
+  },
+  {
+    label: "OCR noise: currency glued to keyword, no space",
+    tags: ["ocr-noise", "real-world-merchant"],
+    rawText: `
+      Corner Deli
+      Sandwich   9.00
+      Total$45.00
+    `,
+    expectedTotal: 45.0,
+    notes: "Simulates Tesseract dropping the space between 'Total' and the currency symbol.",
+  },
+  {
+    label: "OCR noise: 'Total' keyword broken by stray spaces",
+    tags: ["ocr-noise", "known-limitation"],
+    rawText: `
+      Downtown Bakery
+      Croissant     3.25
+      T o t a l     3.25
+    `,
+    expectedTotal: 3.25,
+    notes: "Simulates a common Tesseract artifact where letters get split by spurious spaces, breaking the 'total' substring match. Expected to fail with the current keyword-matching implementation.",
+  },
+  {
+    label: "Whole-dollar total with no cents printed",
+    tags: ["ocr-noise", "known-limitation"],
+    rawText: `
+      Hardware Store
+      Hammer   15
+      Nails     3
+      Total    45
+    `,
+    expectedTotal: 45.0,
+    notes: "Regex requires exactly 2 decimal digits, so a receipt where amounts are printed without cents cannot be matched at all.",
+  },
+  {
+    label: "Three-decimal currency (Kuwaiti Dinar style)",
+    tags: ["international", "known-limitation"],
+    rawText: `
+      Al Salam Store
+      Item A       4.250
+      Item B       3.750
+      Total        8.000
+    `,
+    expectedTotal: 8.0,
+    notes: "Regex is hardcoded to 2 decimal places; 3-decimal currencies are a known unsupported format.",
+  },
+  {
+    label: "All-caps TOTAL with OCR garbage characters",
+    tags: ["ocr-noise"],
+    rawText: `
+      QuickMart
+      Water Bottle   1.50
+      TOTAL |: 1.50
+    `,
+    expectedTotal: 1.5,
+    notes: "Stray pipe/colon characters from OCR misreads around the amount.",
+  },
+  {
+    label: "'Total Items' count line before the real total",
+    tags: ["standard", "distractor"],
+    rawText: `
+      Dollar General
+      Item 1         4.00
+      Item 2         3.00
+      Total Items: 2
+      Total:         7.00
+    `,
+    expectedTotal: 7.0,
+    notes: "'Total Items: 2' has no price match on that line, so scanning must continue to find the real Total line.",
+  },
+  {
+    label: "Refund receipt with negative total",
+    tags: ["known-limitation"],
+    rawText: `
+      Macy's Returns
+      Returned Item      -15.00
+      Total Refund:      -15.00
+    `,
+    expectedTotal: -15.0,
+    notes: "Parser has no minus-sign handling, so refunds are expected to come back as a positive number instead of negative — a known limitation worth flagging.",
+  },
+  {
+    label: "Minimal receipt - bare number only",
+    tags: ["fallback"],
+    rawText: `12.99`,
+    expectedTotal: 12.99,
+    notes: "No labels or keywords at all; must fall back to the single number present.",
+  },
+  {
+    label: "Euro symbol receipt",
+    tags: ["currency-format"],
+    rawText: `
+      Cafe Paris
+      Croissant   €2.50
+      Espresso    €1.80
+      Total       €4.30
+    `,
+    expectedTotal: 4.3,
+    notes: "Euro currency symbol.",
+  },
+  {
+    label: "Pound sterling receipt",
+    tags: ["currency-format"],
+    rawText: `
+      London Corner Shop
+      Sandwich   £3.50
+      Crisps     £1.20
+      Total      £4.70
+    `,
+    expectedTotal: 4.7,
+    notes: "Pound currency symbol.",
+  },
+  {
+    label: "Large US total with thousands separator",
+    tags: ["currency-format"],
+    rawText: `
+      Furniture Warehouse
+      Sofa            1899.00
+      Delivery Fee      99.00
+      Sales Tax        139.90
+      Total          $2,137.90
+    `,
+    expectedTotal: 2137.9,
+    notes: "Four-digit total with comma thousands separator.",
+  },
+  {
+    label: "Large European total with thousands separator",
+    tags: ["currency-format", "international"],
+    rawText: `
+      Möbelhaus Berlin
+      Sofa            1.799,00
+      Lieferung          89,00
+      MwSt              145,90
+      Summe           2.033,90
+    `,
+    expectedTotal: 2033.9,
+    notes: "European thousands/decimal formatting on a 'Summe' (no English keyword) line; also has a German tax line 'MwSt' that must not be confused with the English tax guard.",
+  },
+  {
+    label: "Grand Total overrides earlier partial total",
+    tags: ["standard", "subtotal-handling"],
+    rawText: `
+      Costco
+      Paper Towels    14.00
+      Total items: 3
+      Subtotal        14.00
+      Tax              1.20
+      Grand Total     15.20
+    `,
+    expectedTotal: 15.2,
+    notes: "Bottom-up scan must prefer the final 'Grand Total' line over the earlier partial matches.",
+  },
+  {
+    label: "'Sub Total' spaced variant correctly skipped",
+    tags: ["subtotal-handling"],
+    rawText: `
+      Target
+      Notebook         4.00
+      Sub Total        4.00
+      Tax              0.35
+      Total            4.35
+    `,
+    expectedTotal: 4.35,
+    notes: "Spaced 'Sub Total' variant must still be recognized and skipped.",
+  },
+  {
+    label: "'Total (incl. tax)' single line",
+    tags: ["tax-handling"],
+    rawText: `
+      Burger King
+      Whopper Meal      8.50
+      Total (incl. tax) 8.50
+    `,
+    expectedTotal: 8.5,
+    notes: "Tax-inclusive total must NOT be skipped just because the line mentions 'tax'.",
+  },
+  {
+    label: "Date and phone number distractors",
+    tags: ["distractor"],
+    rawText: `
+      Auto Repair Shop
+      Date: 2026-07-01
+      Call: 555-0142
+      Oil Change      45.00
+      Total:          45.00
+    `,
+    expectedTotal: 45.0,
+    notes: "Dates and phone numbers must not be mistaken for the total.",
+  },
+  {
+    label: "Receipt with VAT-only line correctly skipped",
+    tags: ["tax-handling"],
+    rawText: `
+      Boots Pharmacy
+      Toothpaste       3.20
+      VAT: 0.53
+      Total:           3.20
+    `,
+    expectedTotal: 3.2,
+    notes: "A line mentioning VAT without 'total' must be skipped as a tax line.",
+  },
+];

--- a/src/utils/receiptParser.bench.test.ts
+++ b/src/utils/receiptParser.bench.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { parseReceipt } from "./receiptParser";
+import { benchmarkCases } from "./receiptParser.bench.dataset";
+
+const TOLERANCE = 0.01;
+
+// Regression floor: if accuracy drops below this, something in parseReceipt
+// broke. Raise this number once you've deliberately improved the parser.
+const MIN_ACCEPTABLE_ACCURACY = 70;
+
+describe("Receipt Parser Benchmark", () => {
+  it("reports total-extraction accuracy across a realistic multi-format dataset", () => {
+    const results = benchmarkCases.map((testCase) => {
+      const { total } = parseReceipt(testCase.rawText);
+      const pass =
+        testCase.expectedTotal === null
+          ? total === null
+          : total !== null && Math.abs(total - testCase.expectedTotal) < TOLERANCE;
+      return { ...testCase, actual: total, pass };
+    });
+
+    const passCount = results.filter((r) => r.pass).length;
+    const accuracy = (passCount / results.length) * 100;
+
+    const byTag = new Map<string, { pass: number; total: number }>();
+    for (const r of results) {
+      for (const tag of r.tags) {
+        const entry = byTag.get(tag) ?? { pass: 0, total: 0 };
+        entry.total += 1;
+        if (r.pass) entry.pass += 1;
+        byTag.set(tag, entry);
+      }
+    }
+
+    const lines: string[] = [];
+    lines.push("# Receipt Parser Benchmark Results");
+    lines.push("");
+    lines.push(`Generated: ${new Date().toISOString()}`);
+    lines.push("");
+    lines.push(`**Overall accuracy: ${accuracy.toFixed(1)}% (${passCount}/${results.length} cases)**`);
+    lines.push("");
+    lines.push("## Accuracy by category");
+    lines.push("");
+    lines.push("| Category | Pass | Total | Accuracy |");
+    lines.push("|---|---|---|---|");
+    for (const [tag, { pass, total }] of [...byTag.entries()].sort()) {
+      lines.push(`| ${tag} | ${pass} | ${total} | ${((pass / total) * 100).toFixed(0)}% |`);
+    }
+    lines.push("");
+    lines.push("## Case-by-case results");
+    lines.push("");
+    lines.push("| # | Label | Expected | Actual | Pass |");
+    lines.push("|---|---|---|---|---|");
+    results.forEach((r, i) => {
+      lines.push(
+        `| ${i + 1} | ${r.label} | ${r.expectedTotal ?? "null"} | ${r.actual ?? "null"} | ${r.pass ? "PASS" : "FAIL"} |`,
+      );
+    });
+
+    const failures = results.filter((r) => !r.pass);
+    if (failures.length > 0) {
+      lines.push("");
+      lines.push("## Failures / known limitations");
+      lines.push("");
+      for (const f of failures) {
+        lines.push(`- **${f.label}** — expected ${f.expectedTotal}, got ${f.actual}. ${f.notes}`);
+      }
+    }
+
+    const report = lines.join("\n");
+
+    const outDir = path.join(process.cwd(), "benchmarks", "receipt-parser");
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(path.join(outDir, "results.md"), report);
+    fs.writeFileSync(
+      path.join(outDir, "results.json"),
+      JSON.stringify(
+        {
+          generatedAt: new Date().toISOString(),
+          accuracy,
+          passCount,
+          totalCases: results.length,
+          byTag: Object.fromEntries(byTag),
+          results: results.map((r) => ({
+            label: r.label,
+            tags: r.tags,
+            expectedTotal: r.expectedTotal,
+            actual: r.actual,
+            pass: r.pass,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+
+    console.log("\n" + report + "\n");
+
+    expect(accuracy).toBeGreaterThanOrEqual(MIN_ACCEPTABLE_ACCURACY);
+  });
+});


### PR DESCRIPTION
 Adds a self-contained benchmark for the OCR receipt-parsing logic (`src/utils/receiptParser.ts`) across 31 realistic receipt formats — multiple currencies, US/EU numeric conventions, and common merchant types — achieving **93.5% accuracy (29/31)** and documenting 2 known limitations (unsigned refunds, whole-dollar totals without cents).
- Adds a live evaluation harness for the RAG financial assistant (`RagService`) that seeds deterministic test data through the production indexing path, runs 13 graded questions against the real Groq + Gemini + Pinecone stack, and grades answers with rule-based checks. Latest run: **100% pass rate (13/13)**, avg latency **~2.1s** (min 415ms, max 9.5s).
- Both scripts write their results to `benchmarks/` as committed, reproducible artifacts (`npm run bench:receipts` at the repo root, `npm run bench:rag` in `src/backend`).

## Why
Wanted objective, re-runnable numbers backing the receipt-scanning and AI-assistant features instead of unverified claims — useful both as a regression safety net and as citable metrics.

## Test plan
- [x] `npm run bench:receipts` passes locally (93.5% accuracy, report written to `benchmarks/receipt-parser/`)
- [x] `npm run bench:rag` run end-to-end against a live MySQL + Groq + Gemini + Pinecone stack (100% accuracy, report written to `benchmarks/rag-assistant/`); benchmark user/data cleaned up automatically after the run
- [x] `tsc --noEmit` clean in `src/backend`