### PR TITLE
Fix broken login/register and env loading found while testing the app live

### DIFF
--- a/src/backend/src/config/auth.config.ts
+++ b/src/backend/src/config/auth.config.ts
@@ -1,8 +1,28 @@
+// Properties are getters, not plain values, so each access reads process.env
+// fresh at call time. This module is a static object evaluated once at
+// import time; under ESM, static `import` declarations are always fully
+// evaluated before the importing module's own top-level code runs,
+// regardless of source-line order. index.ts's dotenv loading is a plain
+// statement (not its own imported module), so anything this module imports
+// (this file, transitively via app.js) can end up evaluated — and its
+// process.env reads captured — before dotenv has actually populated
+// process.env. Getters sidestep that entirely by deferring the read.
 const authConfig = {
-    secret: process.env.JWT_SECRET ?? process.env.AUTH_SECRET,
-    secret_expries_in: process.env.JWT_SECRET_EXPIRES_IN ?? process.env.AUTH_SECRET_EXPIRES_IN,
-    refreshToken: process.env.JWT_REFRESH_SECRET ?? process.env.AUTH_REFRESH_SECRET,
-    refreshToken_expries_in: process.env.JWT_REFRESH_SECRET_EXPIRES_IN ?? process.env.AUTH_REFRESH_SECRET_EXPIRES_IN
+    get secret() {
+        return process.env.JWT_SECRET ?? process.env.AUTH_SECRET;
+    },
+    // Defaulted, not required — .env.example lists these alongside the
+    // secrets, but a deployment can reasonably omit them and expect a sane
+    // default rather than an undefined expiresIn.
+    get secret_expries_in() {
+        return process.env.JWT_SECRET_EXPIRES_IN ?? process.env.AUTH_SECRET_EXPIRES_IN ?? "15m";
+    },
+    get refreshToken() {
+        return process.env.JWT_REFRESH_SECRET ?? process.env.AUTH_REFRESH_SECRET;
+    },
+    get refreshToken_expries_in() {
+        return process.env.JWT_REFRESH_SECRET_EXPIRES_IN ?? process.env.AUTH_REFRESH_SECRET_EXPIRES_IN ?? "7d";
+    },
 }
 
 export default authConfig;

--- a/src/backend/src/controllers/auth.controller.ts
+++ b/src/backend/src/controllers/auth.controller.ts
@@ -17,9 +17,42 @@ const getSecrets = () => ({
 });
 
 class AuthController {
+  // Shared by login and register — both end with "issue a valid session for
+  // this user." Previously only login did this, so a freshly-registered user
+  // was shown the dashboard as if authenticated while their session cookies
+  // were never actually set, and every subsequent API call 401'd until they
+  // explicitly logged in.
+  private static issueSession = async (
+    res: Response,
+    user: { id: number; email: string; username: string },
+  ) => {
+    const { access: sec, refresh: refreshSec } = getSecrets();
+
+    const accessToken = sign({ userId: user.id }, sec, {
+      expiresIn: authConfig.secret_expries_in,
+    } as SignOptions);
+
+    const refreshToken = sign({ userId: user.id }, refreshSec, {
+      expiresIn: authConfig.refreshToken_expries_in,
+    } as SignOptions);
+    const hashedRefreshToken = await bcrypt.hash(refreshToken, 10);
+    await prisma.user.update({
+      where: { email: user.email },
+      data: { refreshToken: hashedRefreshToken },
+    });
+    const isProduction = process.env.NODE_ENV === "production";
+    const cookieOptions = {
+      httpOnly: true,
+      secure: isProduction,
+      maxAge: 24 * 60 * 60 * 1000,
+      sameSite: isProduction ? ("none" as const) : ("lax" as const),
+    };
+    res.cookie("accessToken", accessToken, cookieOptions);
+    res.cookie("refreshToken", refreshToken, cookieOptions);
+  };
+
   static login = async (req: Request, res: Response) => {
     const { email, password } = req.body as z.infer<typeof authSchema.login>;
-    const { access: sec, refresh: refreshSec } = getSecrets();
     try {
       const user = await prisma.user.findUnique({
         where: { email },
@@ -32,27 +65,7 @@ class AuthController {
         return Send.unauthorized(res, null, "Incorrect Password");
       }
 
-      const accessToken = sign({ userId: user.id }, sec, {
-        expiresIn: authConfig.secret_expries_in,
-      } as SignOptions);
-
-      const refreshToken = sign({ userId: user.id }, refreshSec, {
-        expiresIn: authConfig.refreshToken_expries_in,
-      } as SignOptions);
-      const hashedRefreshToken = await bcrypt.hash(refreshToken, 10);
-      await prisma.user.update({
-        where: { email },
-        data: { refreshToken: hashedRefreshToken },
-      });
-      const isProduction = process.env.NODE_ENV === "production";
-      const cookieOptions = {
-        httpOnly: true,
-        secure: isProduction,
-        maxAge: 24 * 60 * 60 * 1000,
-        sameSite: isProduction ? ("none" as const) : ("lax" as const),
-      };
-      res.cookie("accessToken", accessToken, cookieOptions);
-      res.cookie("refreshToken", refreshToken, cookieOptions);
+      await AuthController.issueSession(res, user);
 
       return Send.success(res, {
         id: user.id,
@@ -74,7 +87,6 @@ class AuthController {
       const existingUser = await prisma.user.findUnique({
         where: { email },
       });
-      // console.log(existingUser);
       if (existingUser) {
         return Send.error(res, null, "Email is already in use.");
       }
@@ -88,6 +100,9 @@ class AuthController {
           password: hashedPassword,
         },
       });
+
+      await AuthController.issueSession(res, newUser);
+
       return Send.success(
         res,
         {

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -1,5 +1,6 @@
 import "tsconfig-paths/register.js";
 import dotenv from "dotenv";
+import dotenvExpand from "dotenv-expand";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -7,8 +8,11 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Load .env from project root (two levels up from src/backend/src)
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+// Load .env from project root (three levels up from src/backend/src).
+// dotenv-expand resolves ${VAR} references (e.g. DATABASE_URL referencing
+// MYSQL_USER/MYSQL_PASSWORD) — plain dotenv leaves them as literal,
+// unexpanded text, which breaks the Prisma connection string at runtime.
+dotenvExpand.expand(dotenv.config({ path: path.resolve(__dirname, "../../../.env") }));
 
 import App from "./app.js";
 const app = new App();

--- a/src/backend/src/seed-vectors.ts
+++ b/src/backend/src/seed-vectors.ts
@@ -1,9 +1,10 @@
 import dotenv from "dotenv";
+import dotenvExpand from "dotenv-expand";
 import path from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+dotenvExpand.expand(dotenv.config({ path: path.resolve(__dirname, "../../../.env") }));
 import { prisma } from "./db.js";
 import RagService from "./services/rag.service.js";
 


### PR DESCRIPTION
## Summary
Found by actually running the app end-to-end (register → chat) rather than just running unit/benchmark scripts, which never exercised this path:

- **`auth.config.ts`** read `process.env` as a static object at ES module import time, which happens *before* `index.ts`'s dotenv call finishes (an import-hoisting quirk of ES modules) — `authConfig.secret` was permanently `undefined`, so every login threw `secretOrPrivateKey must have a value`. Fixed with lazy getters, matching the pattern already used correctly in `rag.service.ts`. Also defaulted the token-expiry env vars, which were never documented as required alongside `AUTH_SECRET`.
- **`index.ts` and `seed-vectors.ts`** used plain `dotenv.config()`, which doesn't expand `${VAR}` references — `DATABASE_URL`'s `${MYSQL_USER}`/`${MYSQL_PASSWORD}` stayed literal, breaking every DB connection. Already fixed in the benchmark scripts earlier; now fixed in the actual server entrypoint too.
- **`register`** created the user but never issued session cookies (only `login` did), so a freshly-registered user was shown the dashboard as authenticated while every subsequent API call 401'd until they explicitly logged in again. Extracted a shared `issueSession` helper so `register` and `login` both set cookies identically.

## Why
All three were invisible to the benchmark/unit scripts used earlier in this branch's work — they only surfaced when actually driving the running app through a browser (register → add expense → chat), which is why they went unnoticed until now.

## Test plan
- [x] Live Playwright run against the real dev server: register → immediately authenticated (no explicit login needed) → seed expenses via API (200s, not 401s) → open chat widget → verified all 3 chat capabilities (general conversation, spending trends, multi-turn memory) with screenshots
- [x] `curl` verification that `/api/auth/register` now returns `Set-Cookie` headers for both `accessToken` and `refreshToken`
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)