### PR TITLE
Bump CI to Node.js 22

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Get the code from the repository
         uses: actions/checkout@v4
       
-      - name: Set up Node.js version 20
+      - name: Set up Node.js version 22
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
         
       - name: Install dependencies with npm


### PR DESCRIPTION
## Summary
- Bumps the CI workflow from Node 20 to Node 22. Node 20 is deprecated on GitHub Actions runners and was already being silently forced onto Node 24 with a deprecation warning on every run.
- Also re-enabled the workflow itself, which GitHub had auto-disabled after 60 days of repository inactivity — confirmed via `gh workflow list` showing `disabled_inactivity`. None of today's merges (PRs #55-#61) had actually triggered a CI run until this was caught and fixed.

## Test plan
- [x] Manually triggered a run via `workflow_dispatch` after re-enabling — passed in 32s (lint + build green)
- [x] Confirmed `gh workflow list` now shows `active` instead of `disabled_inactivity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)