### PR TITLE
Fix long-description expense failures; add budgets and recurring transactions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,10 @@
 services:
   # MySQL Database
+  # NOTE: the db_data volume was initialized by MySQL 9.4 — an older server
+  # (e.g. 8.0) cannot open it and the container crash-loops with
+  # "Invalid MySQL server downgrade". Keep this image at 9.4 or newer.
   db:
-    image: mysql:8.0
+    image: mysql:9.4
     restart: always
     container_name: expense-db
     environment:

--- a/docs/BUDGETS_AND_RECURRING_TRANSACTIONS.md
+++ b/docs/BUDGETS_AND_RECURRING_TRANSACTIONS.md
@@ -1,0 +1,170 @@
+# Budgets & Recurring Transactions
+
+**Date:** 2026-07-08
+**Branch:** `fix/ai-latest-expense-context`
+**Status:** Implemented, verified end-to-end against the live local API
+
+Two features from the "real financial tracker" roadmap
+(`EXPENSE_CREATION_FIX_AND_VALIDATION.md` §5, items 6 and 7).
+
+---
+
+## 1. Monthly Budgets
+
+Set a monthly spending limit per expense category and see, at a glance, how
+much of it the current month has consumed.
+
+### Data model
+
+New `Budget` table (`schema.prisma`):
+
+```prisma
+model Budget{
+  id        Int      @id @default(autoincrement())
+  category  Category
+  amount    Decimal  @db.Decimal(10, 2)
+  userId    Int
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, category])
+}
+```
+
+One budget per (user, category); the same limit applies to every calendar
+month. Applied with `prisma db push`.
+
+### API
+
+| Method | Route | Behaviour |
+|---|---|---|
+| `GET` | `/api/budgets` | All budgets for the signed-in user |
+| `POST` | `/api/budgets` | Upsert `{ category, amount }` — setting a category that already has a budget overwrites it |
+| `DELETE` | `/api/budgets/:category` | Remove the budget for a category (404 if none, 400 on an unknown category) |
+
+`POST` is validated with the same zod building blocks as expenses
+(`transaction.schema.ts`): valid category enum, positive amount within the
+`DECIMAL(10,2)` range. Bad input returns a per-field 422.
+
+### UI
+
+New **Monthly Budgets** card (`src/components/BudgetManager.tsx`), placed
+between the expense and income forms:
+
+- Every category shows current-month spend; type an amount and press Enter
+  (or the ✓ button) to set its budget.
+- Budgeted categories get a progress bar: **green** under 80%, **amber**
+  80–100%, **red** over 100% with an "Over budget by $X" callout.
+- The × button removes a budget. Errors surface in a banner, same pattern as
+  the forms.
+- Spending is computed client-side from the already-loaded expense list
+  (`useMemo` over the current calendar month), so the card updates instantly
+  when you add or delete an expense.
+
+Supporting pieces: `src/services/budget.service.ts` (normalizes Prisma's
+Decimal-as-string to `number`), `src/utils/useBudgets.tsx` (state hook),
+`Budget` type + `EXPENSE_CATEGORIES` list in `src/types.ts`.
+
+---
+
+## 2. Recurring Transactions That Actually Recur
+
+Previously `isRecurring` was a stored flag with no behaviour. Now a
+transaction marked recurring acts as a **monthly template**: the server
+automatically creates a real copy of it each month.
+
+### How it works
+
+`src/backend/src/services/recurring.service.ts`:
+
+- `App.start()` calls `RecurringService.startScheduler()`, which processes all
+  recurring templates **once at startup** and then **every 12 hours**
+  (`setInterval`, `unref()`ed so it never keeps the process alive).
+- For each expense/income with `isRecurring: true`, the service walks forward
+  one month at a time from `lastRecurredAt ?? date`, creating an occurrence
+  for every month boundary that has passed, and stamping the template's
+  `lastRecurredAt` (new nullable column on both tables) after each one.
+- Generated occurrences are **plain transactions** (`isRecurring: false`) with
+  the template's amount/category/description/payment method, dated exactly one
+  month after the previous occurrence. They're indexed into the AI assistant's
+  vector store like any other transaction (failures there are logged, never
+  fatal).
+
+Design choices worth knowing:
+
+- **Deleting a generated occurrence never resurrects it.** Progress is tracked
+  by `lastRecurredAt` on the template, not by scanning for existing children.
+- **Unchecking "recurring" on the template stops future generation**; deleting
+  the template does too. Already-generated months stay.
+- **Month-end days clamp**: a template dated Jan 31 generates Feb 28 (or 29),
+  then Mar 28 — standard "same day next month, clamped" semantics
+  (`addOneMonthClamped`, exported for testability).
+- **A server that was off for weeks catches up at startup** (capped at 24
+  generated occurrences per template per run as a runaway guard).
+- Each template is processed in its own try/catch, so one bad row can't stall
+  the rest; the run logs `[recurring] Generated N expense(s)...` when it
+  creates anything.
+
+The expense/income forms now label the checkbox
+"Recurring (auto-repeats monthly)" so the behaviour is discoverable.
+
+---
+
+## 3. Files Changed
+
+Backend:
+- `src/backend/prisma/schema.prisma` — `Budget` model; `lastRecurredAt` on `Expense` and `Income`; `budgets` relation on `User`
+- `src/backend/src/services/recurring.service.ts` — **new**, the recurring engine + scheduler
+- `src/backend/src/controllers/budget.controller.ts` — **new**
+- `src/backend/src/routes/budget.routes.ts` — **new**
+- `src/backend/src/validations/transaction.schema.ts` — `budget` schema
+- `src/backend/src/app.ts` — `/api/budgets` routes; scheduler start
+
+Frontend:
+- `src/components/BudgetManager.tsx` — **new**
+- `src/services/budget.service.ts` — **new**
+- `src/utils/useBudgets.tsx` — **new**
+- `src/types.ts` — `Budget` type, `EXPENSE_CATEGORIES`
+- `src/components/ExpenseTracker.tsx` — Budget card wired in
+- `src/components/AddExpenseForm.tsx`, `AddIncomeForm.tsx` — recurring checkbox copy
+
+---
+
+## 4. Verification (run live on 2026-07-08)
+
+Backend `tsc --noEmit` and frontend `tsc -b && vite build`: **clean**.
+
+Against the running local API (test user, all records cleaned up after):
+
+| # | Scenario | Result |
+|---|---|---|
+| B1 | `POST /api/budgets` Food = 300 | ✅ created |
+| B2 | `POST` Food = 450.50 again | ✅ upserted (amount overwritten, still one row) |
+| B3 | `GET /api/budgets` | ✅ lists the single budget |
+| B4 | `POST` with category "Rent" | ✅ 422 `"Invalid expense category"` |
+| B5 | `POST` with amount −5 | ✅ 422 `"Amount must be greater than 0"` |
+| B6 | `DELETE /api/budgets/Food` | ✅ 204, list empty |
+| R1 | Create recurring expense dated 2026-04-23 | ✅ template created |
+| R2 | Restart server | ✅ occurrences auto-generated for 2026-05-23 and 2026-06-23; future 2026-07-23 correctly **not** created |
+| R3 | Restart server again | ✅ still exactly 3 records — no duplicates (idempotent) |
+
+### Deployment note
+
+As with the previous change, run `npx prisma db push` from `src/backend` once
+against the production database when deploying — it adds the `Budget` table
+and the two `lastRecurredAt` columns (both non-destructive).
+
+---
+
+## 5. Known limitations / next steps
+
+- Only a **monthly** cadence is supported. Weekly/yearly would need a
+  `recurrenceInterval` column and a generalized `addInterval` step.
+- Budgets are the same amount every month; per-month overrides (e.g. a bigger
+  December budget) would need a `month` column and a different unique key.
+- Budget progress counts **all** current-month expenses in the category,
+  including auto-generated recurring ones — by design.
+- The scheduler is in-process. If the app ever runs as multiple backend
+  instances, generation should move to a single cron worker or use a
+  transaction-level guard to avoid double-generation.

--- a/docs/EXPENSE_CREATION_FIX_AND_VALIDATION.md
+++ b/docs/EXPENSE_CREATION_FIX_AND_VALIDATION.md
@@ -221,11 +221,10 @@ what a production-grade personal finance app would add next.
    API, especially the auth endpoints.
 
 ### Product features
-6. **Budgets**: per-category monthly budgets with progress bars and
-   over-budget alerts — the single most requested "real tracker" feature.
-7. **Recurring transactions that actually recur**: `isRecurring` is stored
-   but nothing generates the next occurrence. Add a scheduler (cron) that
-   materializes recurring expenses/incomes monthly.
+6. ~~**Budgets**: per-category monthly budgets with progress bars and
+   over-budget alerts~~ — ✅ **done**, see `BUDGETS_AND_RECURRING_TRANSACTIONS.md`.
+7. ~~**Recurring transactions that actually recur**~~ — ✅ **done**, see
+   `BUDGETS_AND_RECURRING_TRANSACTIONS.md`.
 8. **Income editing UI**: the backend `PUT /api/incomes/:id` exists, but the
    frontend has no edit dialog for income (`updateIncome` is commented out in
    `ExpenseTracker.tsx`).

--- a/docs/EXPENSE_CREATION_FIX_AND_VALIDATION.md
+++ b/docs/EXPENSE_CREATION_FIX_AND_VALIDATION.md
@@ -1,0 +1,245 @@
+# Expense Creation Fix & Input Validation Hardening
+
+**Date:** 2026-07-08
+**Branch:** `fix/ai-latest-expense-context`
+**Status:** Implemented, verified end-to-end against the live local API
+
+---
+
+## 1. The Problem
+
+> "When adding expenses with long descriptions, it doesn't get added. It is inconsistent when adding expenses."
+
+Adding an expense sometimes worked and sometimes silently didn't. The trigger was the **length of the description**, which is why it felt random.
+
+### Root cause #1 — the database column was capped at 191 characters
+
+In `src/backend/prisma/schema.prisma`, `description` was declared as a plain
+`String?`. On MySQL, Prisma maps a plain `String` to **`VARCHAR(191)`** by
+default. Any description longer than 191 characters made the `INSERT` fail
+with Prisma error **P2000** ("The provided value for the column is too long").
+
+The API caught that error and returned a generic `500 – Failed to create
+expense`, so nothing explained *why* it failed.
+
+### Root cause #2 — the UI lied about success
+
+`AddExpenseForm.handleSubmit` called `onAddExpense(expenseData)` **without
+awaiting it**, then immediately cleared the form and showed the
+**"Expense Added Successfully"** toast. When the server rejected the request,
+the user still saw a success message and an empty form — but the expense never
+appeared in the list. This is what made the bug feel "inconsistent" instead of
+like a plain error.
+
+### Root cause #3 — no input validation on the expense/income endpoints
+
+Auth routes had zod validation, but `POST/PUT /api/expenses` and
+`POST/PUT /api/incomes` had only a `!amount || !date || !category` check.
+Consequences:
+
+- Oversized descriptions reached the database and blew up there (500 instead of a helpful 422).
+- A non-numeric amount became `NaN`, an unparseable date became `Invalid Date` — both crashed inside Prisma as 500s.
+- `PUT` had **no** required-field check at all: updating with a missing amount produced `NaN` and a 500.
+- Amounts outside `DECIMAL(10,2)` range (> 99,999,999.99) also failed as 500s.
+
+### Bonus issue found while verifying — dev database wouldn't start
+
+`docker-compose.yaml` pinned `mysql:8.0`, but the `db_data` volume had been
+initialized by a MySQL **9.4** server. MySQL refuses to open newer data files
+with an older server ("Invalid MySQL server downgrade"), so the container
+crash-looped and nothing could reach `localhost:3306`.
+
+---
+
+## 2. The Fix
+
+### 2.1 Database: widen the description columns
+
+`src/backend/prisma/schema.prisma` — both `Expense.description` and
+`Income.description` are now:
+
+```prisma
+description     String?         @db.VarChar(500)
+```
+
+Applied to the database with `npx prisma db push` (non-destructive column
+widening) and the Prisma client was regenerated.
+
+**500 characters** was chosen as the canonical limit. It is enforced in three
+places that are deliberately kept in sync:
+
+| Layer | Location | Constant |
+|---|---|---|
+| Database | `schema.prisma` | `@db.VarChar(500)` |
+| API validation | `src/backend/src/validations/transaction.schema.ts` | `MAX_DESCRIPTION_LENGTH = 500` |
+| Frontend | `src/types.ts` | `MAX_DESCRIPTION_LENGTH = 500` |
+
+If you ever change the limit, change **all three**.
+
+### 2.2 Backend: a real validation layer (zod)
+
+New file: `src/backend/src/validations/transaction.schema.ts`
+
+Validation rules now enforced on `POST` and `PUT` for **both** expenses and
+incomes:
+
+| Field | Rule | Error behaviour |
+|---|---|---|
+| `amount` | number (numeric strings coerced), `> 0`, `≤ 99,999,999.99` (the `DECIMAL(10,2)` ceiling), rounded to 2 decimals | 422 with `"Amount must be a number"` / `"Amount must be greater than 0"` / max message |
+| `date` | must parse to a real date, year 1900–2200 | 422 `"Date must be a valid date"` |
+| `category` | must be one of the enum values (expense and income each have their own set) | 422 `"Invalid expense category"` / `"Invalid income category"` |
+| `description` | optional, trimmed, ≤ 500 chars | 422 `"Description cannot exceed 500 characters"` |
+| `paymentMethod` | `CASH \| CREDIT_CARD \| DEBIT_CARD \| UPI`, defaults to `CASH` | 422 `"Invalid payment method"` |
+| `isRecurring` | boolean, defaults to `false` | 422 if not boolean |
+
+Wired into the routers (`expense.routes.ts`, `income.routes.ts`) via the
+existing `ValidateMiddleware.validateBody(...)`, which was upgraded to
+**write the parsed result back to `req.body`** — so controllers now receive
+trimmed strings, coerced types, applied defaults, and no unknown keys
+(zod strips extras like `id`/`userId` that the frontend's update call sends).
+
+Controllers additionally translate a residual Prisma **P2000** into a
+`400 "One of the values is too long"` instead of a generic 500 — a safety net
+in case a value ever slips past validation.
+
+### 2.3 Frontend: honest feedback + guardrails
+
+**`src/components/AddExpenseForm.tsx`**
+- `handleSubmit` now **awaits** `onAddExpense`. The success toast and form
+  reset only happen after the server confirms. On failure, the entered data
+  stays in the form and a red error banner shows the server's message.
+- The description textarea has `maxLength={500}` and a live `N/500` character
+  counter that turns red at the limit.
+- The submit button disables and shows "Adding..." while the request is in
+  flight (prevents double submits).
+- Client-side validity now also requires `amount > 0`.
+
+**`src/components/AddIncomeForm.tsx`** — same treatment (it previously
+swallowed errors with only a `console.error`).
+
+**`src/components/ModalFormExpense.tsx`** (edit dialog) — description capped
+at 500 with the same live counter.
+
+**`src/services/api.ts`** — when the server returns a 422 with per-field
+`errors`, the thrown `Error` now carries the first field message (e.g.
+*"Description cannot exceed 500 characters"*) instead of the generic
+*"Validation error"*, so the form banners show something actionable.
+
+### 2.4 Infrastructure fixes made along the way
+
+- **`docker-compose.yaml`**: `db` image bumped `mysql:8.0` → `mysql:9.4` to
+  match the existing `db_data` volume (see "Bonus issue" above). A comment in
+  the file explains why it must not be downgraded.
+- **`src/backend/prisma.config.ts`**: when a `prisma.config.ts` exists, the
+  Prisma CLI **stops auto-loading `.env`**. The config now loads the
+  project-root `.env` itself using `dotenv` + `dotenv-expand` (identical to
+  how `src/index.ts` does it), so CLI commands like `prisma db push` work
+  again without manually exporting `DATABASE_URL`.
+
+> ⚠️ Note for anyone running the full stack via `docker compose up`: compose
+> prints warnings about unset variables because some values in `.env` contain
+> literal `$` characters, which compose tries to interpolate. If you use the
+> compose-run backend (not the local `npm run dev` one), escape `$` as `$$`
+> in `.env` values, or those values will be silently mangled.
+
+---
+
+## 3. Files Changed
+
+Backend:
+- `src/backend/prisma/schema.prisma` — `@db.VarChar(500)` on both description columns
+- `src/backend/prisma.config.ts` — loads root `.env` for the Prisma CLI
+- `src/backend/src/validations/transaction.schema.ts` — **new**, zod schemas for expense & income
+- `src/backend/src/middlewares/validation.middleware.ts` — parsed body written back to `req.body`
+- `src/backend/src/routes/expense.routes.ts` — validation on POST/PUT
+- `src/backend/src/routes/income.routes.ts` — validation on POST/PUT
+- `src/backend/src/controllers/expenses.controller.ts` — P2000 → 400 with message
+- `src/backend/src/controllers/income.controller.ts` — P2000 → 400 with message
+
+Frontend:
+- `src/types.ts` — shared `MAX_DESCRIPTION_LENGTH`
+- `src/services/api.ts` — surfaces field-level 422 messages
+- `src/components/AddExpenseForm.tsx` — awaited submit, error banner, counter, submitting state
+- `src/components/AddIncomeForm.tsx` — same
+- `src/components/ModalFormExpense.tsx` — description cap + counter
+
+Infra:
+- `docker-compose.yaml` — `mysql:9.4`
+
+---
+
+## 4. Verification (run live on 2026-07-08)
+
+Backend typecheck (`tsc --noEmit`), frontend typecheck + production build
+(`tsc -b && vite build`): **clean**.
+
+End-to-end against the running local API with a fresh test user
+(`cc_test_user@example.com`; test records were deleted afterwards):
+
+| # | Scenario | Result |
+|---|---|---|
+| 1 | `POST /api/expenses` with a **480-character** description | ✅ 200, stored with all 480 chars (previously failed at >191) |
+| 2 | `POST /api/expenses` with a **600-character** description | ✅ 422 `"Description cannot exceed 500 characters"` |
+| 3 | `POST /api/expenses` with `amount: "abc"` | ✅ 422 `"Amount must be a number"` |
+| 4 | `POST /api/expenses` with `date: "not-a-date"` | ✅ 422 `"Date must be a valid date"` |
+| 5 | `POST /api/incomes` with a 480-character description | ✅ 200 |
+
+### Deploying this to a hosted environment (Railway/Render/etc.)
+
+The code changes ship with a normal deploy, but the **database column change
+must be applied to that environment's database** too. This project manages the
+schema with `db push` (the migrations folder predates the Income model), so
+run once against the production `DATABASE_URL`:
+
+```bash
+cd src/backend
+npx prisma db push
+```
+
+Widening `VARCHAR(191)` → `VARCHAR(500)` is non-destructive; existing rows are
+untouched.
+
+---
+
+## 5. Roadmap: toward a fully-fledged financial tracker
+
+The items below are **not implemented yet** — they are the prioritized list of
+what a production-grade personal finance app would add next.
+
+### Correctness & robustness
+1. **Adopt real migrations.** The migration history only covers the original
+   User/Expense tables; Income, `isRecurring`, `paymentMethod`, and this fix
+   all live only in `db push` state. Baseline the current schema with
+   `prisma migrate dev` so production changes become reviewable and reversible.
+2. **Store money as integer cents** (or keep `DECIMAL` but never `Number()`
+   round-trip it) to avoid floating-point drift in totals.
+3. **Backend test suite** (Vitest + supertest): the five scenarios in §4
+   should be an automated regression suite, not a one-off manual check.
+4. **Pagination** on `GET /api/expenses` / `GET /api/incomes` — currently the
+   entire history loads on every page view.
+5. **Rate limiting & security headers** (express-rate-limit, helmet) on the
+   API, especially the auth endpoints.
+
+### Product features
+6. **Budgets**: per-category monthly budgets with progress bars and
+   over-budget alerts — the single most requested "real tracker" feature.
+7. **Recurring transactions that actually recur**: `isRecurring` is stored
+   but nothing generates the next occurrence. Add a scheduler (cron) that
+   materializes recurring expenses/incomes monthly.
+8. **Income editing UI**: the backend `PUT /api/incomes/:id` exists, but the
+   frontend has no edit dialog for income (`updateIncome` is commented out in
+   `ExpenseTracker.tsx`).
+9. **Custom categories** instead of hard-coded enums (requires a `Category`
+   table keyed by user; the enum approach forces a schema change per category).
+10. **Monthly summary dashboard**: net cash flow (income − expenses),
+    month-over-month trends, top merchants.
+11. **CSV/Excel export & import** for interoperability with bank statements.
+12. **Multi-currency support** with a per-user default currency.
+13. **Attachment of receipt images** to expenses (the OCR scanner already
+    exists — persist the image alongside the transaction, e.g. object storage).
+
+### Polish
+14. Code-split the frontend bundle (826 kB main chunk; vite already warns).
+15. Toast system unification — success/error toasts are currently ad-hoc per
+    form; a shared toast context would keep the UX consistent.
+16. Dark-mode styles for `ModalFormExpense` (it is light-mode-only today).

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "nodemon --exec tsx ./src/index.ts",
     "build": "tsc && tsc-alias",
-    "start": "node ./dist/index.js",
+    "start": "npx prisma db push && node ./dist/index.js",
+    "start:no-db-push": "node ./dist/index.js",
     "bench:rag": "tsx ./src/rag-benchmark.ts"
   },
   "keywords": [],

--- a/src/backend/prisma.config.ts
+++ b/src/backend/prisma.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@prisma/config";
+import dotenv from "dotenv";
+import dotenvExpand from "dotenv-expand";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// With a prisma.config.ts present, the Prisma CLI no longer auto-loads .env.
+// Load the project-root .env (two levels up from src/backend) with
+// dotenv-expand so ${VAR} references inside DATABASE_URL resolve, matching
+// how src/index.ts loads it for the running server.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenvExpand.expand(
+  dotenv.config({ path: path.resolve(__dirname, "../../.env") }),
+);
+
+export default defineConfig({
+  datasource: {
+    url: process.env.DATABASE_URL,
+  },
+});

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -11,8 +11,8 @@ model Expense{
   id              Int             @id         @default(autoincrement())
   amount          Decimal         @db.Decimal(10, 2)    
   date            DateTime       
-  category        Category       
-  description     String?
+  category        Category
+  description     String?         @db.VarChar(500)
   userId          Int
   user            User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   isRecurring     Boolean         @default(false)
@@ -24,7 +24,7 @@ model Income{
   amount          Decimal         @db.Decimal(10, 2)
   date            DateTime
   category        IncomeCategory
-  description     String?
+  description     String?         @db.VarChar(500)
   userId          Int
   user            User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   isRecurring     Boolean         @default(false)

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -9,14 +9,17 @@ datasource db {
 
 model Expense{
   id              Int             @id         @default(autoincrement())
-  amount          Decimal         @db.Decimal(10, 2)    
-  date            DateTime       
+  amount          Decimal         @db.Decimal(10, 2)
+  date            DateTime
   category        Category
   description     String?         @db.VarChar(500)
   userId          Int
   user            User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   isRecurring     Boolean         @default(false)
   paymentMethod   PaymentMethod   @default(CASH)
+  // For recurring templates: the date of the last auto-generated occurrence.
+  // Null means no occurrence has been generated yet.
+  lastRecurredAt  DateTime?
 }
 
 model Income{
@@ -29,6 +32,21 @@ model Income{
   user            User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   isRecurring     Boolean         @default(false)
   paymentMethod   PaymentMethod   @default(CASH)
+  lastRecurredAt  DateTime?
+}
+
+// Monthly spending limit per category. One budget per (user, category);
+// the same limit applies to every calendar month.
+model Budget{
+  id              Int             @id         @default(autoincrement())
+  category        Category
+  amount          Decimal         @db.Decimal(10, 2)
+  userId          Int
+  user            User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+
+  @@unique([userId, category])
 }
 
 model User{
@@ -41,6 +59,7 @@ model User{
   updatedAt    DateTime   @updatedAt
   expenses     Expense[]
   incomes      Income[]
+  budgets      Budget[]
 }
 
 enum Category{

--- a/src/backend/src/app.ts
+++ b/src/backend/src/app.ts
@@ -7,6 +7,8 @@ import userRoutes from "@routes/user.routes.js";
 import expenseRoutes from "@routes/expense.routes.js";
 import incomeRoutes from "@routes/income.routes.js";
 import chatRoutes from "@routes/chat.routes.js";
+import budgetRoutes from "@routes/budget.routes.js";
+import RecurringService from "./services/recurring.service.js";
 
 class App {
   private app: Express;
@@ -58,6 +60,7 @@ class App {
     this.app.use("/api/expenses", expenseRoutes);
     this.app.use("/api/incomes", incomeRoutes);
     this.app.use("/api/chat", chatRoutes);
+    this.app.use("/api/budgets", budgetRoutes);
   }
 
   public start() {
@@ -65,6 +68,7 @@ class App {
     const host = appConfig.host ?? "0.0.0.0";
     this.app.listen(port, host, () => {
       console.log(`Server is running on http://${host}:${port}`);
+      RecurringService.startScheduler();
     });
   }
 }

--- a/src/backend/src/controllers/budget.controller.ts
+++ b/src/backend/src/controllers/budget.controller.ts
@@ -1,0 +1,85 @@
+import Send from "@utils/response.utils.js";
+import { prisma } from "../db.js";
+import { Category } from "@prisma/client";
+import type { Request, Response } from "express";
+import type { AuthenticatedRequest } from "../types/express.js";
+
+const isExpenseCategory = (value: string): value is Category =>
+  Object.values(Category).includes(value as Category);
+
+// Helper to get User ID from request (since middleware attaches it)
+const getUserId = (req: Request): number | null => {
+  const authReq = req as AuthenticatedRequest;
+  return authReq.userId ?? null;
+};
+
+class BudgetController {
+  // 1. GET ALL BUDGETS
+  static getBudgets = async (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req);
+      if (!userId) return Send.unauthorized(res, null);
+
+      const budgets = await prisma.budget.findMany({
+        where: { userId },
+        orderBy: { category: "asc" },
+      });
+
+      return Send.success(res, budgets);
+    } catch (error) {
+      console.error("Error fetching budgets:", error);
+      return Send.error(res, null, "Failed to fetch budgets");
+    }
+  };
+
+  // 2. UPSERT BUDGET — one budget per (user, category), so setting a
+  // category that already has a budget overwrites its amount.
+  static upsertBudget = async (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req);
+      if (!userId) return Send.unauthorized(res, null);
+
+      const { category, amount } = req.body;
+
+      const budget = await prisma.budget.upsert({
+        where: { userId_category: { userId, category } },
+        update: { amount },
+        create: { userId, category, amount },
+      });
+
+      return Send.success(res, { budget });
+    } catch (error) {
+      console.error("Failed to save budget:", error);
+      return Send.error(res, null, "Failed to save budget");
+    }
+  };
+
+  // 3. DELETE BUDGET (by category, since that's the natural key the UI has)
+  static deleteBudget = async (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req);
+      if (!userId) return Send.unauthorized(res, null);
+
+      const { category } = req.params;
+      if (!category || !isExpenseCategory(category)) {
+        return Send.badRequest(res, null, "Invalid expense category");
+      }
+
+      const existing = await prisma.budget.findUnique({
+        where: { userId_category: { userId, category } },
+      });
+      if (!existing) {
+        return Send.notFound(res, null, "No budget set for this category");
+      }
+
+      await prisma.budget.delete({ where: { id: existing.id } });
+
+      return res.status(204).send();
+    } catch (error) {
+      console.error("Failed to delete budget:", error);
+      return Send.error(res, null, "Failed to delete budget");
+    }
+  };
+}
+
+export default BudgetController;

--- a/src/backend/src/controllers/expenses.controller.ts
+++ b/src/backend/src/controllers/expenses.controller.ts
@@ -10,6 +10,13 @@ const getUserId = (req: Request): number | null => {
   return authReq.userId ?? null;
 };
 
+// Safety net behind the zod layer: if a value still exceeds a column limit
+// (Prisma error P2000), tell the client what happened instead of a 500.
+const isValueTooLongError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { code?: string }).code === "P2000";
+
 class ExpenseController {
   // 1. GET ALL EXPENSES
   static getExpenses = async (req: Request, res: Response) => {
@@ -73,6 +80,9 @@ class ExpenseController {
       return Send.success(res, { expense: createExpense });
     } catch (error) {
       console.error("Failed to create expense: ", error);
+      if (isValueTooLongError(error)) {
+        return Send.badRequest(res, null, "One of the values is too long");
+      }
       return Send.error(res, null, "Failed to create expense");
     }
   };
@@ -162,7 +172,10 @@ class ExpenseController {
       return Send.success(res, { expense: updatedExpense });
     } catch (error) {
       console.error("Failed to update expense:", error);
-      return Send.error(res, null);
+      if (isValueTooLongError(error)) {
+        return Send.badRequest(res, null, "One of the values is too long");
+      }
+      return Send.error(res, null, "Failed to update expense");
     }
   };
 }

--- a/src/backend/src/controllers/income.controller.ts
+++ b/src/backend/src/controllers/income.controller.ts
@@ -22,6 +22,13 @@ const getUserId = (req: Request): number | null => {
   return authReq.userId ?? null;
 };
 
+// Safety net behind the zod layer: if a value still exceeds a column limit
+// (Prisma error P2000), tell the client what happened instead of a 500.
+const isValueTooLongError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { code?: string }).code === "P2000";
+
 class IncomeController {
   // 1. GET ALL INCOMES
   static getIncomes = async (req: Request, res: Response) => {
@@ -83,6 +90,9 @@ class IncomeController {
       return Send.success(res, { income: createdIncome });
     } catch (error) {
       console.error("Failed to create income: ", error);
+      if (isValueTooLongError(error)) {
+        return Send.badRequest(res, null, "One of the values is too long");
+      }
       return Send.error(res, null, "Failed to create income");
     }
   };
@@ -173,7 +183,10 @@ class IncomeController {
       return Send.success(res, { income: updatedIncome });
     } catch (error) {
       console.error("Failed to update income:", error);
-      return Send.error(res, null);
+      if (isValueTooLongError(error)) {
+        return Send.badRequest(res, null, "One of the values is too long");
+      }
+      return Send.error(res, null, "Failed to update income");
     }
   };
 }

--- a/src/backend/src/middlewares/validation.middleware.ts
+++ b/src/backend/src/middlewares/validation.middleware.ts
@@ -14,7 +14,9 @@ class ValidateMiddleware {
   static validateBody(schema: ParsableSchema) {
     return (req: Request, res: Response, next: NextFunction) => {
       try {
-        schema.parse(req.body);
+        // Replace the body with the parsed result so downstream handlers see
+        // trimmed strings, coerced types, defaults, and no unknown keys.
+        req.body = schema.parse(req.body);
         next();
       } catch (err) {
         if (err instanceof ZodError) {

--- a/src/backend/src/routes/budget.routes.ts
+++ b/src/backend/src/routes/budget.routes.ts
@@ -1,0 +1,35 @@
+import BudgetController from "@controllers/budget.controller.js";
+import BaseRouter, { type RouteConfig } from "./router.js";
+import AuthMiddleware from "@middlewares/auth.middleware.js";
+import ValidateMiddleware from "@middlewares/validation.middleware.js";
+import transactionSchema from "../validations/transaction.schema.js";
+
+class BudgetRouter extends BaseRouter {
+  protected routes(): RouteConfig[] {
+    return [
+      {
+        method: "get",
+        path: "/",
+        middlewares: [AuthMiddleware.authenticateUser],
+        handler: BudgetController.getBudgets,
+      },
+      {
+        method: "post",
+        path: "/",
+        middlewares: [
+          AuthMiddleware.authenticateUser,
+          ValidateMiddleware.validateBody(transactionSchema.budget),
+        ],
+        handler: BudgetController.upsertBudget,
+      },
+      {
+        method: "delete",
+        path: "/:category",
+        middlewares: [AuthMiddleware.authenticateUser],
+        handler: BudgetController.deleteBudget,
+      },
+    ];
+  }
+}
+
+export default new BudgetRouter().router;

--- a/src/backend/src/routes/expense.routes.ts
+++ b/src/backend/src/routes/expense.routes.ts
@@ -1,6 +1,8 @@
 import ExpenseController from "@controllers/expenses.controller.js";
 import BaseRouter, { type RouteConfig } from "./router.js";
 import AuthMiddleware from "@middlewares/auth.middleware.js";
+import ValidateMiddleware from "@middlewares/validation.middleware.js";
+import transactionSchema from "../validations/transaction.schema.js";
 
 class ExpenseRouter extends BaseRouter {
   protected routes(): RouteConfig[] {
@@ -14,13 +16,19 @@ class ExpenseRouter extends BaseRouter {
       {
         method: "post",
         path: "/",
-        middlewares: [AuthMiddleware.authenticateUser],
+        middlewares: [
+          AuthMiddleware.authenticateUser,
+          ValidateMiddleware.validateBody(transactionSchema.expense),
+        ],
         handler: ExpenseController.createExpense,
       },
       {
         method: "put",
         path: "/:expenseId",
-        middlewares: [AuthMiddleware.authenticateUser],
+        middlewares: [
+          AuthMiddleware.authenticateUser,
+          ValidateMiddleware.validateBody(transactionSchema.expense),
+        ],
         handler: ExpenseController.updateExpense,
       },
       {

--- a/src/backend/src/routes/income.routes.ts
+++ b/src/backend/src/routes/income.routes.ts
@@ -1,6 +1,8 @@
 import IncomeController from "@controllers/income.controller.js";
 import BaseRouter, { type RouteConfig } from "./router.js";
 import AuthMiddleware from "@middlewares/auth.middleware.js";
+import ValidateMiddleware from "@middlewares/validation.middleware.js";
+import transactionSchema from "../validations/transaction.schema.js";
 
 class IncomeRouter extends BaseRouter {
   protected routes(): RouteConfig[] {
@@ -14,13 +16,19 @@ class IncomeRouter extends BaseRouter {
       {
         method: "post",
         path: "/",
-        middlewares: [AuthMiddleware.authenticateUser],
+        middlewares: [
+          AuthMiddleware.authenticateUser,
+          ValidateMiddleware.validateBody(transactionSchema.income),
+        ],
         handler: IncomeController.createIncome,
       },
       {
         method: "put",
         path: "/:incomeId",
-        middlewares: [AuthMiddleware.authenticateUser],
+        middlewares: [
+          AuthMiddleware.authenticateUser,
+          ValidateMiddleware.validateBody(transactionSchema.income),
+        ],
         handler: IncomeController.updateIncome,
       },
       {

--- a/src/backend/src/services/recurring.service.ts
+++ b/src/backend/src/services/recurring.service.ts
@@ -1,0 +1,125 @@
+import { prisma } from "../db.js";
+import RagService from "./rag.service.js";
+
+// How often the scheduler re-checks for due recurring transactions. It also
+// runs once at server startup, so a server that was off for weeks catches up
+// immediately.
+const CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
+
+// Hard cap on occurrences generated per template per run — bounds the work if
+// a template is years in the past.
+const MAX_OCCURRENCES_PER_RUN = 24;
+
+// Add one month, clamping the day so e.g. Jan 31 -> Feb 28 -> (stays 28) Mar 28.
+// Uses UTC parts since transaction dates are stored as date-only instants.
+export const addOneMonthClamped = (date: Date): Date => {
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  const day = date.getUTCDate();
+  const lastDayOfNextMonth = new Date(Date.UTC(year, month + 2, 0)).getUTCDate();
+  return new Date(
+    Date.UTC(year, month + 1, Math.min(day, lastDayOfNextMonth)),
+  );
+};
+
+type TransactionKind = "expense" | "income";
+
+class RecurringService {
+  private static timer: NodeJS.Timeout | null = null;
+
+  static startScheduler() {
+    if (this.timer) return;
+    // Run once at startup (fire and forget), then on the interval.
+    void this.processAll();
+    this.timer = setInterval(() => void this.processAll(), CHECK_INTERVAL_MS);
+    // Don't keep the process alive just for the scheduler.
+    this.timer.unref();
+  }
+
+  static async processAll() {
+    try {
+      const [expenses, incomes] = await Promise.all([
+        this.processKind("expense"),
+        this.processKind("income"),
+      ]);
+      if (expenses + incomes > 0) {
+        console.log(
+          `[recurring] Generated ${expenses} expense(s) and ${incomes} income(s)`,
+        );
+      }
+    } catch (error) {
+      console.error("[recurring] Failed to process recurring transactions:", error);
+    }
+  }
+
+  // For every template (a transaction with isRecurring=true), generate one
+  // occurrence per elapsed month since the template's date (or since the last
+  // generated occurrence). Occurrences are plain transactions with
+  // isRecurring=false; lastRecurredAt on the template tracks progress, so
+  // deleting a generated occurrence never causes it to be re-created.
+  private static async processKind(kind: TransactionKind): Promise<number> {
+    // prisma.expense and prisma.income share the shape this service needs.
+    const delegate = (kind === "expense" ? prisma.expense : prisma.income) as
+      typeof prisma.expense;
+
+    const templates = await delegate.findMany({
+      where: { isRecurring: true },
+    });
+
+    const now = new Date();
+    let created = 0;
+
+    for (const template of templates) {
+      try {
+        let anchor = template.lastRecurredAt ?? template.date;
+
+        for (let i = 0; i < MAX_OCCURRENCES_PER_RUN; i++) {
+          const next = addOneMonthClamped(anchor);
+          if (next > now) break;
+
+          const occurrence = await delegate.create({
+            data: {
+              amount: template.amount,
+              date: next,
+              category: template.category,
+              description: template.description,
+              userId: template.userId,
+              isRecurring: false,
+              paymentMethod: template.paymentMethod,
+            },
+          });
+          await delegate.update({
+            where: { id: template.id },
+            data: { lastRecurredAt: next },
+          });
+
+          try {
+            if (kind === "expense") {
+              await RagService.indexExpense(occurrence);
+            } else {
+              await RagService.indexIncome(occurrence);
+            }
+          } catch (aiError) {
+            console.error(
+              `[recurring] Failed to index generated ${kind} for AI:`,
+              aiError,
+            );
+          }
+
+          anchor = next;
+          created++;
+        }
+      } catch (error) {
+        // One broken template must not stop the rest.
+        console.error(
+          `[recurring] Failed processing ${kind} template #${template.id}:`,
+          error,
+        );
+      }
+    }
+
+    return created;
+  }
+}
+
+export default RecurringService;

--- a/src/backend/src/validations/transaction.schema.ts
+++ b/src/backend/src/validations/transaction.schema.ts
@@ -82,12 +82,20 @@ const income = z.object({
   paymentMethod: paymentMethodSchema,
 });
 
+// Monthly spending limit for one expense category.
+const budget = z.object({
+  category: expenseCategorySchema,
+  amount: amountSchema,
+});
+
 export type ExpenseInput = z.infer<typeof expense>;
 export type IncomeInput = z.infer<typeof income>;
+export type BudgetInput = z.infer<typeof budget>;
 
 const transactionSchema = {
   expense,
   income,
+  budget,
 };
 
 export default transactionSchema;

--- a/src/backend/src/validations/transaction.schema.ts
+++ b/src/backend/src/validations/transaction.schema.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+// Keep in sync with the DB column (@db.VarChar(500) in schema.prisma) and the
+// frontend MAX_DESCRIPTION_LENGTH in src/types.ts.
+export const MAX_DESCRIPTION_LENGTH = 500;
+
+// Matches DECIMAL(10, 2) in the database: 8 integer digits + 2 fraction digits.
+export const MAX_AMOUNT = 99_999_999.99;
+
+const amountSchema = z.coerce
+  .number({ message: "Amount must be a number" })
+  .positive("Amount must be greater than 0")
+  .max(MAX_AMOUNT, `Amount cannot exceed ${MAX_AMOUNT}`)
+  .refine((n) => Number.isFinite(n), "Amount must be a finite number")
+  // DECIMAL(10,2) silently rounds anyway; do it explicitly so the value the
+  // client gets back matches what was stored.
+  .transform((n) => Math.round(n * 100) / 100);
+
+const dateSchema = z.coerce
+  .date({ message: "Date must be a valid date" })
+  .refine(
+    (d) => d.getFullYear() >= 1900 && d.getFullYear() <= 2200,
+    "Date must be between years 1900 and 2200",
+  );
+
+const descriptionSchema = z
+  .string({ message: "Description must be text" })
+  .trim()
+  .max(
+    MAX_DESCRIPTION_LENGTH,
+    `Description cannot exceed ${MAX_DESCRIPTION_LENGTH} characters`,
+  )
+  .optional()
+  .default("");
+
+const paymentMethodSchema = z
+  .enum(["CASH", "CREDIT_CARD", "DEBIT_CARD", "UPI"], {
+    message: "Invalid payment method",
+  })
+  .optional()
+  .default("CASH");
+
+const isRecurringSchema = z
+  .boolean({ message: "isRecurring must be true or false" })
+  .optional()
+  .default(false);
+
+const expenseCategorySchema = z.enum(
+  [
+    "Food",
+    "Groceries",
+    "Mobile_Bill",
+    "Travel",
+    "Shopping",
+    "Games",
+    "Subscription",
+    "EMI",
+  ],
+  { message: "Invalid expense category" },
+);
+
+const incomeCategorySchema = z.enum(
+  ["Salary", "Freelance", "Investment", "Gift", "Other"],
+  { message: "Invalid income category" },
+);
+
+const expense = z.object({
+  amount: amountSchema,
+  date: dateSchema,
+  category: expenseCategorySchema,
+  description: descriptionSchema,
+  isRecurring: isRecurringSchema,
+  paymentMethod: paymentMethodSchema,
+});
+
+const income = z.object({
+  amount: amountSchema,
+  date: dateSchema,
+  category: incomeCategorySchema,
+  description: descriptionSchema,
+  isRecurring: isRecurringSchema,
+  paymentMethod: paymentMethodSchema,
+});
+
+export type ExpenseInput = z.infer<typeof expense>;
+export type IncomeInput = z.infer<typeof income>;
+
+const transactionSchema = {
+  expense,
+  income,
+};
+
+export default transactionSchema;

--- a/src/components/AddExpenseForm.tsx
+++ b/src/components/AddExpenseForm.tsx
@@ -249,7 +249,10 @@ const AddExpenseForm = ({ onAddExpense }: expenseProps) => {
               htmlFor="isRecurring"
               className="text-sm font-medium text-zinc-700 dark:text-zinc-300 cursor-pointer"
             >
-              Recurring Expense
+              Recurring Expense{" "}
+              <span className="text-zinc-400 dark:text-zinc-500 font-normal">
+                (auto-repeats monthly)
+              </span>
             </label>
           </div>
           <div className="flex gap-4 pt-4">

--- a/src/components/AddExpenseForm.tsx
+++ b/src/components/AddExpenseForm.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 import type { newExpense, Category, PaymentMethod } from "../types";
+import { MAX_DESCRIPTION_LENGTH } from "../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faRotateRight, faCamera } from "@fortawesome/free-solid-svg-icons";
 import ReceiptScanner from "./ReceiptScanner";
 
 type expenseProps = {
-  onAddExpense: (expense: newExpense) => void;
+  onAddExpense: (expense: newExpense) => Promise<{ success: boolean } | void>;
 };
 
 const AddExpenseForm = ({ onAddExpense }: expenseProps) => {
@@ -14,13 +15,20 @@ const AddExpenseForm = ({ onAddExpense }: expenseProps) => {
   const [desc, setDesc] = useState("");
   const [category, setCategory] = useState<Category>("Food");
   const [showToast, setShowToast] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [isRecurring, setIsRecurring] = useState(false);
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("CASH");
 
   const [showScanner, setShowScanner] = useState(false);
 
   const amt = Number(amount);
-  const isValid = amount.trim() !== "" && !Number.isNaN(amt) && date !== "";
+  const isValid =
+    amount.trim() !== "" &&
+    !Number.isNaN(amt) &&
+    amt > 0 &&
+    date !== "" &&
+    desc.length <= MAX_DESCRIPTION_LENGTH;
 
   const handleScanComplete = (scannedAmount: number) => {
     setAmount(scannedAmount.toString());
@@ -28,26 +36,40 @@ const AddExpenseForm = ({ onAddExpense }: expenseProps) => {
     if (!desc) setDesc("Scanned Receipt");
   };
 
-  const handleSubmit = (e: React.FormEvent<Element>) => {
+  const handleSubmit = async (e: React.FormEvent<Element>) => {
     e.preventDefault();
-    if (!isValid) {
+    if (!isValid || isSubmitting) {
       return;
     }
     const expenseData = {
       amount: parseFloat(amount),
       date: date,
-      description: desc,
+      description: desc.trim(),
       category: category,
       isRecurring: isRecurring,
       paymentMethod: paymentMethod,
     };
-    onAddExpense(expenseData);
-    setAmount("");
-    setDate(new Date().toISOString().slice(0, 10));
-    setDesc("");
-    setCategory("Food");
-    setShowToast(true);
-    setTimeout(() => setShowToast(false), 1500);
+    setIsSubmitting(true);
+    setErrorMessage(null);
+    try {
+      // Only clear the form and show success once the server confirms —
+      // previously the toast fired even when the request failed.
+      await onAddExpense(expenseData);
+      setAmount("");
+      setDate(new Date().toISOString().slice(0, 10));
+      setDesc("");
+      setCategory("Food");
+      setShowToast(true);
+      setTimeout(() => setShowToast(false), 1500);
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error
+          ? err.message
+          : "Failed to add expense. Please try again.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleReset = (e: React.FormEvent<Element>) => {
@@ -138,17 +160,29 @@ const AddExpenseForm = ({ onAddExpense }: expenseProps) => {
           </div>
           {/**Description Data*/}
           <div>
-            <label
-              htmlFor="desc"
-              className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2"
-            >
-              Description
-            </label>
+            <div className="flex items-center justify-between mb-2">
+              <label
+                htmlFor="desc"
+                className="block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+              >
+                Description
+              </label>
+              <span
+                className={`text-xs ${
+                  desc.length >= MAX_DESCRIPTION_LENGTH
+                    ? "text-red-500"
+                    : "text-zinc-400 dark:text-zinc-500"
+                }`}
+              >
+                {desc.length}/{MAX_DESCRIPTION_LENGTH}
+              </span>
+            </div>
             <textarea
               id="desc"
               className="w-full bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 text-zinc-900 dark:text-zinc-100 px-4 py-3 rounded-xl focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:focus:ring-zinc-100 focus:border-transparent transition-all resize-none"
               name="Expense Description"
               rows={3}
+              maxLength={MAX_DESCRIPTION_LENGTH}
               value={desc}
               onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
                 setDesc(e.target.value)
@@ -221,9 +255,10 @@ const AddExpenseForm = ({ onAddExpense }: expenseProps) => {
           <div className="flex gap-4 pt-4">
             <button
               type="submit"
-              className="flex-1 bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 font-medium py-3 px-6 rounded-xl hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-all focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:focus:ring-zinc-100 focus:ring-offset-2 dark:focus:ring-offset-zinc-800"
+              disabled={isSubmitting}
+              className="flex-1 bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 font-medium py-3 px-6 rounded-xl hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-all focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:focus:ring-zinc-100 focus:ring-offset-2 dark:focus:ring-offset-zinc-800 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              Add Expense
+              {isSubmitting ? "Adding..." : "Add Expense"}
             </button>
             <button
               className="px-6 py-3 bg-white dark:bg-zinc-700 border border-zinc-200 dark:border-zinc-600 text-zinc-700 dark:text-zinc-300 font-medium rounded-xl hover:bg-zinc-50 dark:hover:bg-zinc-600 transition-all focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:focus:ring-zinc-100 focus:ring-offset-2 dark:focus:ring-offset-zinc-800"
@@ -233,6 +268,27 @@ const AddExpenseForm = ({ onAddExpense }: expenseProps) => {
             </button>
           </div>
         </form>
+        {errorMessage && (
+          <div
+            className="flex items-center gap-3 mt-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-xl"
+            role="alert"
+          >
+            <svg
+              className="w-5 h-5 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span className="text-sm font-medium">{errorMessage}</span>
+          </div>
+        )}
         {showToast && (
           <div
             className="flex items-center gap-3 mt-6 p-4 bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 rounded-xl"

--- a/src/components/AddIncomeForm.tsx
+++ b/src/components/AddIncomeForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { IncomeCategory, PaymentMethod, newIncome } from "../types";
+import { MAX_DESCRIPTION_LENGTH } from "../types";
 
 type IncomeFormProps = {
   onAddIncome: (income: newIncome) => Promise<{ success: boolean } | void>;
@@ -12,23 +13,32 @@ const AddIncomeForm = ({ onAddIncome }: IncomeFormProps) => {
   const [category, setCategory] = useState<IncomeCategory>("Salary");
   const [isRecurring, setIsRecurring] = useState(false);
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("CASH");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const amt = Number(amount);
-  const isValid = amount.trim() !== "" && !Number.isNaN(amt) && date !== "";
+  const isValid =
+    amount.trim() !== "" &&
+    !Number.isNaN(amt) &&
+    amt > 0 &&
+    date !== "" &&
+    desc.length <= MAX_DESCRIPTION_LENGTH;
 
   const handleSubmit = async (e: React.FormEvent<Element>) => {
     e.preventDefault();
-    if (!isValid) return;
+    if (!isValid || isSubmitting) return;
 
     const incomeData: newIncome = {
       amount: parseFloat(amount),
       date,
-      description: desc,
+      description: desc.trim(),
       category,
       isRecurring,
       paymentMethod,
     };
 
+    setIsSubmitting(true);
+    setErrorMessage(null);
     try {
       await onAddIncome(incomeData);
       setAmount("");
@@ -39,7 +49,13 @@ const AddIncomeForm = ({ onAddIncome }: IncomeFormProps) => {
       setIsRecurring(false);
     } catch (err) {
       console.error("Failed to submit income:", err);
-      // Optional: surface a toast or inline error here if you’d like
+      setErrorMessage(
+        err instanceof Error
+          ? err.message
+          : "Failed to add income. Please try again.",
+      );
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -96,14 +112,26 @@ const AddIncomeForm = ({ onAddIncome }: IncomeFormProps) => {
           </div>
 
           <div>
-            <label
-              htmlFor="income-desc"
-              className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2"
-            >
-              Description
-            </label>
+            <div className="flex items-center justify-between mb-2">
+              <label
+                htmlFor="income-desc"
+                className="block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+              >
+                Description
+              </label>
+              <span
+                className={`text-xs ${
+                  desc.length >= MAX_DESCRIPTION_LENGTH
+                    ? "text-red-500"
+                    : "text-zinc-400 dark:text-zinc-500"
+                }`}
+              >
+                {desc.length}/{MAX_DESCRIPTION_LENGTH}
+              </span>
+            </div>
             <textarea
               id="income-desc"
+              maxLength={MAX_DESCRIPTION_LENGTH}
               className="w-full bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 text-zinc-900 dark:text-zinc-100 px-4 py-3 rounded-xl focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:focus:ring-zinc-100 focus:border-transparent transition-all resize-none"
               rows={3}
               value={desc}
@@ -176,11 +204,33 @@ const AddIncomeForm = ({ onAddIncome }: IncomeFormProps) => {
 
           <button
             type="submit"
-            className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-medium py-3 px-6 rounded-xl transition-all focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+            disabled={isSubmitting}
+            className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-medium py-3 px-6 rounded-xl transition-all focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Add Income
+            {isSubmitting ? "Adding..." : "Add Income"}
           </button>
         </form>
+        {errorMessage && (
+          <div
+            className="flex items-center gap-3 mt-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-xl"
+            role="alert"
+          >
+            <svg
+              className="w-5 h-5 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span className="text-sm font-medium">{errorMessage}</span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/AddIncomeForm.tsx
+++ b/src/components/AddIncomeForm.tsx
@@ -198,7 +198,10 @@ const AddIncomeForm = ({ onAddIncome }: IncomeFormProps) => {
               htmlFor="income-isRecurring"
               className="text-sm font-medium text-zinc-700 dark:text-zinc-300 cursor-pointer"
             >
-              Recurring Income
+              Recurring Income{" "}
+              <span className="text-zinc-400 dark:text-zinc-500 font-normal">
+                (auto-repeats monthly)
+              </span>
             </label>
           </div>
 

--- a/src/components/BudgetManager.tsx
+++ b/src/components/BudgetManager.tsx
@@ -1,0 +1,202 @@
+import { useMemo, useState } from "react";
+import type { Budget, Category, Expense } from "../types";
+import { EXPENSE_CATEGORIES } from "../types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark, faCheck } from "@fortawesome/free-solid-svg-icons";
+
+type BudgetManagerProps = {
+  budgets: Budget[];
+  expenses: Expense[];
+  onSaveBudget: (category: Category, amount: number) => Promise<void>;
+  onRemoveBudget: (category: Category) => Promise<void>;
+};
+
+const prettyCategory = (category: Category) => category.replace(/_/g, " ");
+
+// Progress bar color by budget usage: calm below 80%, warning to 100%, alarm over
+const barColor = (ratio: number) => {
+  if (ratio > 1) return "bg-red-500";
+  if (ratio >= 0.8) return "bg-amber-500";
+  return "bg-emerald-500";
+};
+
+const BudgetManager = ({
+  budgets,
+  expenses,
+  onSaveBudget,
+  onRemoveBudget,
+}: BudgetManagerProps) => {
+  // Draft input values keyed by category; only categories being edited appear
+  const [drafts, setDrafts] = useState<Partial<Record<Category, string>>>({});
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [savingCategory, setSavingCategory] = useState<Category | null>(null);
+
+  const budgetByCategory = useMemo(() => {
+    const map = new Map<Category, Budget>();
+    budgets.forEach((b) => map.set(b.category, b));
+    return map;
+  }, [budgets]);
+
+  // Current calendar month spending per category
+  const spentByCategory = useMemo(() => {
+    const now = new Date();
+    const map = new Map<Category, number>();
+    expenses.forEach((exp) => {
+      const d = new Date(exp.date);
+      if (
+        d.getFullYear() === now.getFullYear() &&
+        d.getMonth() === now.getMonth()
+      ) {
+        map.set(exp.category, (map.get(exp.category) ?? 0) + Number(exp.amount));
+      }
+    });
+    return map;
+  }, [expenses]);
+
+  const handleSave = async (category: Category) => {
+    const raw = drafts[category];
+    if (raw === undefined) return;
+    const amount = Number(raw);
+    if (raw.trim() === "" || Number.isNaN(amount) || amount <= 0) {
+      setErrorMessage("Budget must be a positive number");
+      return;
+    }
+    setSavingCategory(category);
+    setErrorMessage(null);
+    try {
+      await onSaveBudget(category, amount);
+      setDrafts((prev) => {
+        const next = { ...prev };
+        delete next[category];
+        return next;
+      });
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error ? err.message : "Failed to save budget",
+      );
+    } finally {
+      setSavingCategory(null);
+    }
+  };
+
+  const handleRemove = async (category: Category) => {
+    setErrorMessage(null);
+    try {
+      await onRemoveBudget(category);
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error ? err.message : "Failed to remove budget",
+      );
+    }
+  };
+
+  const monthLabel = new Date().toLocaleString("default", {
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <div className="bg-white dark:bg-zinc-800 rounded-2xl border border-zinc-200 dark:border-zinc-700 p-8 transition-colors duration-200">
+      <div className="flex items-baseline justify-between mb-6">
+        <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100 tracking-tight">
+          Monthly Budgets
+        </h2>
+        <span className="text-sm text-zinc-500 dark:text-zinc-400">
+          {monthLabel}
+        </span>
+      </div>
+
+      <div className="space-y-5">
+        {EXPENSE_CATEGORIES.map((category) => {
+          const budget = budgetByCategory.get(category);
+          const spent = spentByCategory.get(category) ?? 0;
+          const draft = drafts[category];
+          const isEditing = draft !== undefined;
+          const ratio = budget ? spent / budget.amount : 0;
+
+          return (
+            <div key={category}>
+              <div className="flex items-center justify-between gap-3 mb-1.5">
+                <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                  {prettyCategory(category)}
+                </span>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                    ${spent.toFixed(2)}
+                    {budget ? ` / $${budget.amount.toFixed(2)}` : " spent"}
+                  </span>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    placeholder={budget ? budget.amount.toFixed(2) : "Set"}
+                    aria-label={`Budget for ${prettyCategory(category)}`}
+                    className="w-24 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 text-zinc-900 dark:text-zinc-100 px-2 py-1 text-sm rounded-lg focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:focus:ring-zinc-100 focus:border-transparent transition-all"
+                    value={draft ?? ""}
+                    onChange={(e) =>
+                      setDrafts((prev) => ({
+                        ...prev,
+                        [category]: e.target.value,
+                      }))
+                    }
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleSave(category);
+                    }}
+                  />
+                  {isEditing && (
+                    <button
+                      type="button"
+                      onClick={() => handleSave(category)}
+                      disabled={savingCategory === category}
+                      className="p-1.5 rounded-lg bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-colors disabled:opacity-50"
+                      title="Save budget"
+                    >
+                      <FontAwesomeIcon icon={faCheck} className="w-3 h-3" />
+                    </button>
+                  )}
+                  {budget && !isEditing && (
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(category)}
+                      className="p-1.5 rounded-lg text-zinc-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                      title="Remove budget"
+                    >
+                      <FontAwesomeIcon icon={faXmark} className="w-3 h-3" />
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {budget && (
+                <div>
+                  <div className="w-full h-2 bg-zinc-100 dark:bg-zinc-700 rounded-full overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all duration-300 ${barColor(ratio)}`}
+                      style={{ width: `${Math.min(ratio * 100, 100)}%` }}
+                    />
+                  </div>
+                  {ratio > 1 && (
+                    <p className="text-xs text-red-500 mt-1">
+                      Over budget by ${(spent - budget.amount).toFixed(2)}
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {errorMessage && (
+        <div
+          className="mt-6 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-xl text-sm font-medium"
+          role="alert"
+        >
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BudgetManager;

--- a/src/components/ExpenseTracker.tsx
+++ b/src/components/ExpenseTracker.tsx
@@ -20,6 +20,8 @@ import IncomeList from "./IncomeList";
 import TotalIncome from "./TotalIncome";
 import useIncomeFilter from "../utils/useIncomeFilter";
 import IncomeChart from "./IncomeChart";
+import useBudgets from "../utils/useBudgets";
+import BudgetManager from "./BudgetManager";
 
 const ExpenseTracker = () => {
   const { user, logout } = useAuth();
@@ -30,6 +32,7 @@ const ExpenseTracker = () => {
     deleteIncome,
     // updateIncome, // reserved for future editing support
   } = useIncomeCrud();
+  const { budgets, saveBudget, removeBudget } = useBudgets();
 
   // Filter hook - filters the raw expenses
   const {
@@ -182,6 +185,12 @@ const ExpenseTracker = () => {
         <div className="grid grid-cols-1 xl:grid-cols-2 gap-12 items-start">
           <div className="space-y-10">
             <AddExpenseForm onAddExpense={addExpense} />
+            <BudgetManager
+              budgets={budgets}
+              expenses={expense}
+              onSaveBudget={saveBudget}
+              onRemoveBudget={removeBudget}
+            />
             <AddIncomeForm onAddIncome={addIncome} />
           </div>
 

--- a/src/components/ModalFormExpense.tsx
+++ b/src/components/ModalFormExpense.tsx
@@ -11,6 +11,7 @@ import {
   Textarea,
 } from "@headlessui/react";
 import type { Expense, Category, PaymentMethod } from "../types";
+import { MAX_DESCRIPTION_LENGTH } from "../types";
 import { useState } from "react";
 
 interface modalClose {
@@ -125,11 +126,25 @@ const ModalFormExpense = ({
 
             {/* Description */}
             <div>
-              <Label className="block text-sm font-medium text-zinc-700 mb-2">
-                Description
-              </Label>
+              <div className="flex items-center justify-between mb-2">
+                <Label className="block text-sm font-medium text-zinc-700">
+                  Description
+                </Label>
+                <span
+                  className={`text-xs ${
+                    (tempExpValues.description?.length ?? 0) >=
+                    MAX_DESCRIPTION_LENGTH
+                      ? "text-red-500"
+                      : "text-zinc-400"
+                  }`}
+                >
+                  {tempExpValues.description?.length ?? 0}/
+                  {MAX_DESCRIPTION_LENGTH}
+                </span>
+              </div>
               <Textarea
                 rows={3}
+                maxLength={MAX_DESCRIPTION_LENGTH}
                 className="w-full rounded-xl border border-zinc-200 bg-white text-zinc-900 px-4 py-3 focus:ring-2 focus:ring-zinc-900 focus:border-transparent focus:outline-none transition-all resize-none"
                 value={tempExpValues.description}
                 onChange={(e) =>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -49,8 +49,16 @@ class ApiService {
       const data = await response.json();
 
       if (!response.ok) {
+        // Validation failures (422) carry per-field messages in `errors`;
+        // surface those instead of the generic "Validation error" banner.
+        const fieldErrors = data.errors as Record<string, string[]> | undefined;
+        const firstFieldError = fieldErrors
+          ? Object.values(fieldErrors).flat()[0]
+          : undefined;
         throw new Error(
-          data.message || `Request failed with status ${response.status}`,
+          firstFieldError ||
+            data.message ||
+            `Request failed with status ${response.status}`,
         );
       }
 

--- a/src/services/budget.service.ts
+++ b/src/services/budget.service.ts
@@ -1,0 +1,39 @@
+import api from "./api";
+import type { Budget, Category } from "../types";
+
+interface BudgetResponse {
+  budget: Budget;
+}
+
+// Prisma Decimal serializes to a string in JSON — normalize to number
+const normalize = (budget: Budget): Budget => ({
+  ...budget,
+  amount: Number(budget.amount),
+});
+
+export const budgetService = {
+  async getAll(): Promise<Budget[]> {
+    const response = await api.get<Budget[]>("/budgets");
+    const budgets = Array.isArray(response.data) ? response.data : [];
+    return budgets.map(normalize);
+  },
+
+  // One budget per category — the server upserts
+  async save(category: Category, amount: number): Promise<Budget> {
+    const response = await api.post<BudgetResponse>("/budgets", {
+      category,
+      amount,
+    });
+    const saved = response.data?.budget;
+    if (!saved) {
+      throw new Error("Server response missing budget data");
+    }
+    return normalize(saved);
+  },
+
+  async remove(category: Category): Promise<void> {
+    await api.delete(`/budgets/${category}`);
+  },
+};
+
+export default budgetService;

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,3 +46,22 @@ export type Income = {
 };
 
 export type newIncome = Omit<Income, "id">;
+
+// Monthly spending limit for one expense category (one per category per user)
+export type Budget = {
+  id: number;
+  category: Category;
+  amount: number;
+  userId?: number;
+};
+
+export const EXPENSE_CATEGORIES: Category[] = [
+  "Food",
+  "Groceries",
+  "Mobile_Bill",
+  "Travel",
+  "Shopping",
+  "Games",
+  "Subscription",
+  "EMI",
+];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,7 @@
+// Keep in sync with the backend zod schema (transaction.schema.ts) and the
+// @db.VarChar(500) columns in schema.prisma.
+export const MAX_DESCRIPTION_LENGTH = 500;
+
 // Category and PaymentMethod types matching Prisma schema
 export type Category =
   | "Food"

--- a/src/utils/useBudgets.tsx
+++ b/src/utils/useBudgets.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import type { Budget, Category } from "../types";
+import { budgetService } from "../services/budget.service";
+
+const useBudgets = () => {
+  const [budgets, setBudgets] = useState<Budget[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchBudgets = async () => {
+      try {
+        setLoading(true);
+        setBudgets(await budgetService.getAll());
+      } catch (err: unknown) {
+        console.error("Error fetching budgets: ", err);
+        setError(
+          err instanceof Error ? err.message : "Failed to fetch budgets",
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchBudgets();
+  }, []);
+
+  const saveBudget = async (category: Category, amount: number) => {
+    const saved = await budgetService.save(category, amount);
+    setBudgets((prev) => {
+      const exists = prev.some((b) => b.category === category);
+      return exists
+        ? prev.map((b) => (b.category === category ? saved : b))
+        : [...prev, saved];
+    });
+  };
+
+  const removeBudget = async (category: Category) => {
+    await budgetService.remove(category);
+    setBudgets((prev) => prev.filter((b) => b.category !== category));
+  };
+
+  return { budgets, saveBudget, removeBudget, loading, error };
+};
+
+export default useBudgets;


### PR DESCRIPTION
## Summary
- **Bug fix**: expense/income descriptions were capped at VARCHAR(191) in MySQL, so longer descriptions failed with a generic 500 while the UI showed a success toast. Columns widened to VARCHAR(500), a zod validation layer added on all expense/income endpoints (per-field 422s), and the forms now await the server and surface real error messages.
- **Monthly budgets**: new `Budget` model (one per user + category), `GET/POST/DELETE /api/budgets`, and a Monthly Budgets card with per-category progress bars and over-budget alerts.
- **Recurring transactions**: transactions marked `isRecurring` act as monthly templates. A scheduler (startup + every 12h) materializes one real transaction per elapsed month, with month-end clamping and idempotent progress tracking via `lastRecurredAt`.
- **Self-migrating deploys**: `npm run start` now runs `prisma db push` before booting, so Render applies the schema changes (VarChar(500), Budget table, lastRecurredAt) automatically on deploy.
- Infra: MySQL dev container pinned to 9.4 to match the data volume; `prisma.config.ts` loads the root `.env` for CLI commands.

Docs: `docs/EXPENSE_CREATION_FIX_AND_VALIDATION.md` and `docs/BUDGETS_AND_RECURRING_TRANSACTIONS.md`.

## Test plan
- Backend `tsc --noEmit`, frontend `tsc -b && vite build`: clean
- Live API tests (local): 480-char description stored; 600-char/bad amount/bad date rejected with clear 422s; budget upsert/list/delete verified; recurring template dated 2 months back generated exactly the 2 due occurrences, skipped the future one, and produced no duplicates across restarts
- Post-merge: verify on the live Render backend (health, budgets endpoint, long-description expense)

🤖 Generated with [Claude Code](https://claude.com/claude-code)