### PR TITLE
Add password-confirmed account deletion (DELETE /api/user)

### DIFF
--- a/src/backend/src/controllers/user.controller.ts
+++ b/src/backend/src/controllers/user.controller.ts
@@ -1,5 +1,7 @@
 import Send from "@utils/response.utils.js";
 import { prisma } from "../db.js";
+import bcrypt from "bcrypt";
+import RagService from "../services/rag.service.js";
 import type { Request, Response } from "express";
 import type { AuthenticatedRequest } from "../types/express.js";
 
@@ -24,6 +26,66 @@ class UserController {
     } catch (error) {
       console.error("Error fetching user info:", error);
       return Send.error(res, {}, "Internal server error");
+    }
+  };
+
+  // Delete the signed-in user's own account and all their data. Requires the
+  // account password in the body as confirmation, since this is irreversible.
+  static deleteAccount = async (req: Request, res: Response) => {
+    try {
+      const userId = (req as AuthenticatedRequest).userId;
+      if (!userId) return Send.unauthorized(res, null);
+
+      const { password } = req.body ?? {};
+      if (!password || typeof password !== "string") {
+        return Send.badRequest(
+          res,
+          null,
+          "Password confirmation is required to delete the account",
+        );
+      }
+
+      const user = await prisma.user.findUnique({ where: { id: userId } });
+      if (!user) return Send.notFound(res, null, "User not found");
+
+      const passwordMatches = await bcrypt.compare(password, user.password);
+      if (!passwordMatches) {
+        return Send.forbidden(res, null, "Incorrect password");
+      }
+
+      // Best-effort cleanup of this user's vectors in the AI index — the DB
+      // cascade below removes the rows, but the index is external.
+      try {
+        const [expenses, incomes] = await Promise.all([
+          prisma.expense.findMany({ where: { userId }, select: { id: true } }),
+          prisma.income.findMany({ where: { userId }, select: { id: true } }),
+        ]);
+        for (const { id } of expenses) {
+          await RagService.deleteIndexedExpense(id);
+        }
+        for (const { id } of incomes) {
+          await RagService.deleteIndexedIncome(id);
+        }
+      } catch (aiError) {
+        console.error("Failed to clean AI index during account deletion:", aiError);
+      }
+
+      // Cascades to expenses, incomes, and budgets (onDelete: Cascade)
+      await prisma.user.delete({ where: { id: userId } });
+
+      const isProduction = process.env.NODE_ENV === "production";
+      const cookieOptions = {
+        httpOnly: true,
+        secure: isProduction,
+        sameSite: isProduction ? ("none" as const) : ("lax" as const),
+      };
+      res.clearCookie("accessToken", cookieOptions);
+      res.clearCookie("refreshToken", cookieOptions);
+
+      return Send.success(res, null, "Account deleted");
+    } catch (error) {
+      console.error("Failed to delete account:", error);
+      return Send.error(res, null, "Failed to delete account");
     }
   };
 }

--- a/src/backend/src/routes/user.routes.ts
+++ b/src/backend/src/routes/user.routes.ts
@@ -12,6 +12,13 @@ class UserRoutes extends BaseRouter{
                 ],
                 handler: UserController.getUser
             },
+            {method: "delete",
+                path: "/",
+                middlewares: [
+                    AuthMiddleware.authenticateUser
+                ],
+                handler: UserController.deleteAccount
+            },
         ]
     }
 }


### PR DESCRIPTION
## Summary
Adds `DELETE /api/user`: the signed-in user can delete their own account. Requires the account password in the body as confirmation (403 on mismatch, 400 if missing), best-effort deletes the user vectors from the AI index, relies on `onDelete: Cascade` for expenses/incomes/budgets, and clears the auth cookies.

Also the immediate motivation: removing the `cc_test_user` verification account from production cleanly through the API.

## Test plan
- Backend typecheck clean
- Local: wrong password → 403, missing password → 400, correct password → account deleted, subsequent login → 401
- Post-merge: delete the production test user via the endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)